### PR TITLE
fix(agent): model menu-teardown ops in textgrid so read_screen has no ghost text

### DIFF
--- a/tests/test_textgrid.py
+++ b/tests/test_textgrid.py
@@ -330,3 +330,183 @@ def test_render_screen_history_cell_bounded_for_wide_grid():
     data = b"".join(f"W{i}\r\n".encode() for i in range(3000))
     r = textgrid.render_screen(data, 500, 4, view="scrollback", lines=100000)
     assert r["history_lines"] <= 100_000 // 500   # == 200
+
+
+# ---- #28: menu-teardown ops (scroll regions, IL/DL, ICH/DCH/ECH, SU/SD) -----
+#
+# A TUI tears a menu down with line/char insert-delete, scroll-region resets or
+# private erases. The old textgrid dropped all of these, so closed menus left
+# ghost text. These verify the ops are modeled — by PARITY WITH PYTE for every
+# sequence pyte itself dispatches, and by direct assertion for SU/SD (which pyte
+# does not implement, so a parity check there would be meaningless).
+
+def _pyte_grid(data: bytes, cols: int, rows: int) -> str:
+    pyte = pytest.importorskip("pyte")
+    screen = pyte.Screen(cols, rows)
+    stream = pyte.ByteStream(screen)
+    stream.feed(data)
+    return "\n".join(screen.display)
+
+
+def _fill(cols: int, rows: int) -> bytes:
+    # CUP-place AAA, BBB, CCC ... one label per row (no reliance on LF/scroll).
+    return b"".join(b"\x1b[%d;1H%s" % (i + 1, (chr(ord("A") + i) * 3).encode())
+                    for i in range(rows))
+
+
+@pytest.mark.parametrize("seq", [
+    b"\x1b[2;1H\x1b[L",             # IL: insert 1 blank line at row 2
+    b"\x1b[2;1H\x1b[2L",            # IL x2
+    b"\x1b[2;1H\x1b[M",             # DL: delete 1 line at row 2
+    b"\x1b[2;1H\x1b[3M",            # DL x3 (more than rows below)
+    b"\x1b[1;2H\x1b[2@",            # ICH: insert 2 blanks
+    b"\x1b[1;2H\x1b[9@",            # ICH past the right edge (clip)
+    b"\x1b[1;2H\x1b[2P",            # DCH: delete 2 chars
+    b"\x1b[1;2H\x1b[9P",            # DCH past the end (clamp)
+    b"\x1b[1;3H\x1b[3X",            # ECH: erase 3 chars in place
+    b"\x1b[3;1H\x1b[?0J",           # DECSED ?0J (== ED 0)
+    b"\x1b[3;1H\x1b[?J",            # DECSED ?J default
+    b"\x1b[3;1H\x1b[?1J",           # DECSED ?1J (start -> cursor)
+    b"\x1b[1;2H\x1b[?0K",           # DECSEL ?0K (== EL 0)
+    b"\x1b[1;2H\x1b[?2K",           # DECSEL ?2K (whole line)
+    b"\x1b[2;4r",                   # DECSTBM set region (homes cursor)
+    b"\x1b[2;4r\x1b[H",             # DECSTBM + explicit home
+    b"\x1b[r",                      # DECSTBM reset to full screen
+    b"\x1b[4;2r",                   # DECSTBM invalid (top>=bot): no-op
+    b"\x1b[2;4r\x1b[2;1H\x1b[L",    # IL inside a scroll region
+    b"\x1b[2;4r\x1b[4;1H\x1b[M",    # DL at the region's bottom row
+    b"\x1b[2;3r\x1b[5;1H\x1b[L",    # IL with cursor OUTSIDE region -> no-op
+    b"\x1b[2;3r\x1b[5;1H\x1b[M",    # DL with cursor outside region -> no-op
+])
+def test_menu_ops_parity_with_pyte(seq):
+    pytest.importorskip("pyte")
+    cols, rows = 8, 5
+    data = _fill(cols, rows) + seq
+    assert textgrid.render(data, cols, rows) == _pyte_grid(data, cols, rows)
+
+
+def test_decstbm_scroll_within_region_parity():
+    # Set a 3-row region, home, then feed CRLF-separated lines so the region
+    # scrolls while the rows outside it stay fixed. Must match pyte exactly.
+    cols, rows = 8, 5
+    data = _fill(cols, rows) + b"\x1b[2;4r\x1b[2;1H" + b"".join(
+        b"r%d\r\n" % i for i in range(6))
+    assert textgrid.render(data, cols, rows) == _pyte_grid(data, cols, rows)
+
+
+def test_su_scrolls_full_screen_up():
+    # SU 1 with the default region: every row moves up, blank at the bottom.
+    text = textgrid.render(_fill(8, 5) + b"\x1b[S", 8, 5)
+    assert _grid(text) == ["BBB     ", "CCC     ", "DDD     ", "EEE     ",
+                           "        "]
+
+
+def test_sd_scrolls_full_screen_down():
+    text = textgrid.render(_fill(8, 5) + b"\x1b[T", 8, 5)
+    assert _grid(text) == ["        ", "AAA     ", "BBB     ", "CCC     ",
+                           "DDD     "]
+
+
+def test_su_sd_within_scroll_region_keep_outside_rows():
+    # Region = rows 2-4; SU/SD scroll only inside it. Row 1 (AAA) and row 5
+    # (EEE) are sentinels that must never move.
+    up = textgrid.render(_fill(8, 5) + b"\x1b[2;4r\x1b[S", 8, 5)
+    assert _grid(up) == ["AAA     ", "CCC     ", "DDD     ", "        ",
+                         "EEE     "]
+    down = textgrid.render(_fill(8, 5) + b"\x1b[2;4r\x1b[T", 8, 5)
+    assert _grid(down) == ["AAA     ", "        ", "BBB     ", "CCC     ",
+                           "EEE     "]
+
+
+def test_ich_clips_at_right_edge():
+    data = b"\x1b[1;1HABCDEFGH\x1b[1;3H\x1b[2@"   # insert 2 blanks at col 3
+    assert _grid(textgrid.render(data, 8, 1))[0] == "AB  CDEF"   # GH pushed off
+    assert _grid(textgrid.render(data, 8, 1))[0] == _pyte_grid(data, 8, 1)
+
+
+def test_dch_pads_right_with_blanks():
+    data = b"\x1b[1;1HABCDEFGH\x1b[1;3H\x1b[2P"   # delete CD, shift left
+    assert _grid(textgrid.render(data, 8, 1))[0] == "ABEFGH  "
+    assert _grid(textgrid.render(data, 8, 1))[0] == _pyte_grid(data, 8, 1)
+
+
+def test_ech_erases_in_place_without_shifting():
+    data = b"\x1b[1;1HABCDEFGH\x1b[1;3H\x1b[2X"   # blank cols 3-4 only
+    assert _grid(textgrid.render(data, 8, 1))[0] == "AB  EFGH"
+    assert _grid(textgrid.render(data, 8, 1))[0] == _pyte_grid(data, 8, 1)
+
+
+def test_char_ops_at_last_column_dont_overflow():
+    # n far larger than the columns remaining must clamp, never raise/overflow.
+    for op in (b"\x1b[9@", b"\x1b[9P", b"\x1b[9X"):
+        data = b"\x1b[1;1HABCDEFGH\x1b[1;8H" + op
+        out = _grid(textgrid.render(data, 8, 2))
+        assert len(out) == 2 and all(len(ln) == 8 for ln in out)
+
+
+def test_menu_teardown_leaves_no_ghost_text():
+    # The #28 symptom: draw a menu (rows 2-4), then tear it down with DL. The
+    # rows below close up and NO menu glyph survives (the old textgrid kept
+    # them as ghost text because it ignored DL).
+    base = (b"\x1b[1;1Hheader"
+            + b"\x1b[2;1HMENU-AAAA"
+            + b"\x1b[3;1HMENU-BBBB"
+            + b"\x1b[4;1HMENU-CCCC"
+            + b"\x1b[5;1Hfooter")
+    text = textgrid.render(base + b"\x1b[2;1H\x1b[3M", 10, 5)   # DL x3 at row 2
+    assert "MENU" not in text
+    assert "header" in text and "footer" in text
+
+
+def test_scroll_region_does_not_pollute_history_when_top_nonzero():
+    # A partial-region scroll (top>0) is a TUI menu scroll, NOT real shell
+    # scrollback — it must not leak into history (#21/#28 review point).
+    data = _fill(8, 5) + b"\x1b[2;4r\x1b[4;1H" + b"".join(
+        b"x%d\r\n" % i for i in range(10))
+    r = textgrid.render_screen(data, 8, 5, view="scrollback", lines=50)
+    assert r["history_lines"] == 0
+
+
+def test_one_row_grid_scroll_ops_never_raise():
+    # Degenerate 1-row grid: region is a single line; scroll/IL/DL must be safe.
+    for seq in (b"\x1b[S", b"\x1b[T", b"\x1b[L", b"\x1b[M", b"\x1b[1;1r\x1bM"):
+        out = textgrid.render(b"\x1b[1;1HX" + seq, 4, 1)
+        assert len(_grid(out)) == 1 and len(_grid(out)[0]) == 4
+
+
+# ---- #28 part 2: evicted-ring head resync (don't mis-decode a cut sequence) -
+
+def test_trim_for_screen_resyncs_evicted_head():
+    # Head evicted mid-CSI: starts with '2;5HGHOST' (the ESC '[' was dropped).
+    data = b"2;5HGHOST\x1b[1;1Hclean"
+    # evicted + no restart marker -> resync to the first ESC, dropping the cut.
+    assert textgrid._trim_for_screen(data, evicted=True) == b"\x1b[1;1Hclean"
+    # not evicted -> the head is the true start, kept verbatim.
+    assert textgrid._trim_for_screen(data, evicted=False) == data
+    # a restart marker always wins, evicted or not.
+    d2 = b"old stuff\x1b[2Jnew"
+    assert textgrid._trim_for_screen(d2, evicted=True) == b"\x1b[2Jnew"
+    assert textgrid._trim_for_screen(d2, evicted=False) == b"\x1b[2Jnew"
+
+
+def test_trim_for_screen_matches_raw_trim_behaviour():
+    # _trim_for_screen must mirror snapshot/raw._trim for the evicted case.
+    from webterm.agent.snapshot import raw as raw_snap
+    data = b"23;42Hgarbage\x1b[31mred"   # the test_snapshot_raw fixture shape
+    assert textgrid._trim_for_screen(data, evicted=True) == \
+        raw_snap._trim(data, evicted=True)
+
+
+@pytest.mark.parametrize("force_textgrid", [False, True])
+def test_render_screen_text_evicted_resync(monkeypatch, force_textgrid):
+    # Both render paths (pyte and the textgrid fallback) must drop a cut leading
+    # sequence when the ring evicted its head, instead of rendering ghost text.
+    from webterm.agent import agent as agent_mod
+    if force_textgrid:
+        monkeypatch.setitem(sys.modules, "pyte", None)
+    else:
+        pytest.importorskip("pyte")
+    data = b"2;5HGHOST\x1b[1;1Hclean"
+    r = agent_mod._render_screen_text(data, 20, 3, evicted=True)
+    assert "GHOST" not in r["text"]
+    assert "clean" in r["text"]

--- a/webterm/agent/agent.py
+++ b/webterm/agent/agent.py
@@ -35,7 +35,7 @@ _DETECT_INTERVAL = 1.5
 
 def _render_screen_text(data: bytes, cols: int, rows: int,
                         view: str = "screen", lines: int = 0,
-                        alt_screen: bool = False):
+                        alt_screen: bool = False, evicted: bool = False):
     """Render the ring for an MCP read; return a dict
     ``{text, degraded, alt_screen, cursor, view, history_lines}``. Runs in a
     worker thread; never raises (#15, #21).
@@ -46,8 +46,10 @@ def _render_screen_text(data: bytes, cols: int, rows: int,
     fallback. ``alt_screen`` (the agent's live-tracked state) overrides
     ``view="scrollback"`` — the grid is the whole story for a full-screen TUI,
     so scrollback is meaningless; the returned ``view`` reflects what was
-    actually produced. ``degraded=True`` (``view="raw"``, ``cursor=None``) is
-    the last-ditch raw decode when no grid could be produced (#15 symptom)."""
+    actually produced. ``evicted`` (the ring dropped its head) lets the
+    head-trim resync a cut leading escape sequence instead of mis-decoding it
+    into ghost glyphs (#28). ``degraded=True`` (``view="raw"``, ``cursor=None``)
+    is the last-ditch raw decode when no grid could be produced (#15 symptom)."""
     try:
         cols = max(1, int(cols))
         rows = max(1, int(rows))
@@ -56,13 +58,15 @@ def _render_screen_text(data: bytes, cols: int, rows: int,
     want_scrollback = view == "scrollback" and not alt_screen
     eff_view = "scrollback" if want_scrollback else "screen"
     if not want_scrollback:
-        # Current screen only: pyte (high fidelity), trimmed like textgrid.
+        # Current screen only: pyte (high fidelity), trimmed like textgrid —
+        # with the same evicted-head resync so a cut leading sequence can't
+        # mis-decode into top-left ghost glyphs (#28).
         try:
             import pyte  # type: ignore
-            from .snapshot.textgrid import _trim_to_last_restart
+            from .snapshot.textgrid import _trim_for_screen
             screen = pyte.Screen(cols, rows)
             stream = pyte.ByteStream(screen)
-            stream.feed(_trim_to_last_restart(data))
+            stream.feed(_trim_for_screen(data, evicted))
             cur = {"row": min(max(screen.cursor.y, 0), rows - 1),
                    "col": min(max(screen.cursor.x, 0), cols - 1)}
             return {"text": "\n".join(screen.display), "degraded": False,
@@ -74,7 +78,8 @@ def _render_screen_text(data: bytes, cols: int, rows: int,
     # textgrid: scrollback (it owns history) OR the no-pyte screen fallback.
     try:
         from .snapshot import textgrid
-        r = textgrid.render_screen(data, cols, rows, eff_view, lines)
+        r = textgrid.render_screen(data, cols, rows, eff_view, lines,
+                                   evicted=evicted)
         return {"text": r["text"], "degraded": False, "alt_screen": alt_screen,
                 "cursor": r["cursor"], "view": eff_view,
                 "history_lines": r["history_lines"]}
@@ -377,6 +382,7 @@ class Agent:
         # large ring) and enqueue the reply on the SAME ordered out-queue.
         loop = asyncio.get_running_loop()
         data = self.ring.get()
+        evicted = self.ring.evicted              # head may start mid-seq (#28)
         cols, rows = self.state.cols, self.state.rows
         alt = self.state.alt_screen
         app_cursor = self.state.app_cursor       # DECCKM (#23)
@@ -385,7 +391,7 @@ class Agent:
             try:
                 r = await loop.run_in_executor(
                     None, _render_screen_text, data, cols, rows, view, lines,
-                    alt)
+                    alt, evicted)
                 self._enqueue("txt", protocol.screen_text_frame(
                     req, r["text"], cols, rows, degraded=r["degraded"],
                     alt_screen=r["alt_screen"], cursor=r["cursor"],

--- a/webterm/agent/snapshot/textgrid.py
+++ b/webterm/agent/snapshot/textgrid.py
@@ -8,7 +8,9 @@ grid with box-drawing and braille glyphs intact, instead of the unbounded
 raw-ANSI dump the old fallback produced (issue #15).
 
 Scope: enough of the VT/ECMA-48 model to lay cursor-addressed output onto a grid
-— CUP/CUU/CUD/CUF/CUB/CHA/VPA cursor moves, ED/EL erase, autowrap, the
+— CUP/CUU/CUD/CUF/CUB/CHA/VPA cursor moves, ED/EL erase (incl. private DECSED/
+DECSEL ``?J``/``?K``), ICH/DCH/ECH char insert/delete/erase, IL/DL line
+insert/delete, SU/SD and DECSTBM scroll-region scrolling, autowrap, the
 CR/LF/BS/TAB controls, RIS/RI, cursor save/restore, and alternate-screen entry
 (clears, like a real fresh alt buffer). SGR (color/style), other DEC private
 modes (synchronized update, cursor visibility), and OSC/DCS/SOS/PM/APC control
@@ -20,8 +22,10 @@ output size and (via dimension caps + replay trimming) compute.
 
 Known limits vs pyte (cost fidelity, never boundedness/safety — the primary
 pyte path covers these, and this is a best-effort fallback, not a second full
-emulator): no scroll regions (DECSTBM), no IL/DL/ICH/DCH, no separate
-wrap-pending cell, and wide (CJK)/combining glyphs counted as one column.
+emulator): no DEC origin mode (DECOM ``?6h``, so CUP stays screen-absolute even
+under a scroll region), no separate wrap-pending cell, and wide (CJK)/combining
+glyphs counted as one column. Scroll regions (DECSTBM), IL/DL, ICH/DCH, ECH and
+SU/SD ARE modeled (#28) so a TUI's menu-teardown ops don't leave ghost text.
 """
 
 from __future__ import annotations
@@ -120,15 +124,34 @@ def _skip_string(text: str, k: int, n: int) -> int:
     return n
 
 
-def _trim_to_last_restart(data: bytes) -> bytes:
-    """Drop everything before the last full clear / alt-screen entry — it is
-    not visible on the settled screen — so a 50-frame TUI capture renders only
-    its final frame. No marker → unchanged."""
+def _trim_for_screen(data: bytes, evicted: bool = False) -> bytes:
+    """Trim the ring for a current-screen render. Drop everything before the
+    last full clear / alt-screen entry — invisible on the settled screen — so a
+    50-frame TUI capture renders only its final frame. With no such marker, an
+    **evicted** ring head may begin mid-escape-sequence, so resync to the first
+    LF or ESC; otherwise the head is the true start and is kept. Mirrors
+    :func:`webterm.agent.snapshot.raw._trim` so the MCP screen render can't
+    mis-decode a truncated leading sequence into ghost glyphs near top-left
+    (#28). Dropping a partial leading line is the accepted tradeoff (that
+    fragment would render mis-positioned anyway)."""
     best = max(data.rfind(m) for m in _RESTART_MARKERS)
-    return data[best:] if best > 0 else data
+    if best > 0:
+        return data[best:]
+    if best == 0 or not evicted:
+        return data
+    candidates = [i for i in (data.find(b"\n"), data.find(b"\x1b")) if i >= 0]
+    return data[min(candidates):] if candidates else data
 
 
-def _replay(data: bytes, cols: int, rows: int, trim: bool = True):
+def _trim_to_last_restart(data: bytes) -> bytes:
+    """Marker-only trim (no eviction resync) — equivalent to
+    ``_trim_for_screen(data, evicted=False)``. Kept for callers that don't track
+    ring-eviction state."""
+    return _trim_for_screen(data)
+
+
+def _replay(data: bytes, cols: int, rows: int, trim: bool = True,
+            evicted: bool = False):
     """Replay ``data`` (raw PTY bytes) onto a fresh ``rows``x``cols`` grid.
     Returns ``(grid, cursor_x, cursor_y, history)`` where ``history`` is the
     lines that scrolled off the top of the PRIMARY screen (bounded; never
@@ -149,24 +172,44 @@ def _replay(data: bytes, cols: int, rows: int, trim: bool = True):
     x = y = 0
     saved: Tuple[int, int] = (0, 0)
     in_alt = False
-    text = (_trim_to_last_restart(data) if trim else data).decode(
+    # DECSTBM scroll region [top, bot], inclusive, 0-based (default: whole
+    # screen). Scrolling, IL/DL and SU/SD act within it; rows outside stay put.
+    top, bot = 0, rows - 1
+    text = (_trim_for_screen(data, evicted) if trim else data).decode(
         "utf-8", "replace")
     n = len(text)
     i = 0
 
+    def scroll_up(count: int = 1) -> None:
+        # Scroll the [top, bot] region up by `count`: a row leaves at the top of
+        # the region, a blank appears at the bottom; rows outside are untouched.
+        # pop(top)+insert(bot, blank) keeps the row count and the outside rows
+        # fixed — correct ONLY because `bot` is the post-pop insertion index.
+        for _ in range(max(1, count)):
+            if top == 0 and not in_alt:          # full-screen scroll = history
+                history.append("".join(grid[top]))
+            grid.pop(top)
+            grid.insert(bot, [" "] * cols)
+
+    def scroll_down(count: int = 1) -> None:
+        # Scroll the [top, bot] region down by `count`: a blank at the top, a row
+        # leaves at the bottom; rows outside the region are untouched.
+        for _ in range(max(1, count)):
+            grid.insert(top, [" "] * cols)
+            grid.pop(bot + 1)
+
     def newline() -> None:
         nonlocal y
-        y += 1
-        if y > rows - 1:
-            if not in_alt:                       # primary scroll = real history
-                history.append("".join(grid[0]))
-            grid.pop(0)
-            grid.append([" "] * cols)
-            y = rows - 1
+        if y == bot:                             # at bottom margin -> scroll
+            scroll_up(1)
+        elif y < rows - 1:                       # else move down (clamp at edge)
+            y += 1
 
     def clear() -> None:
+        nonlocal top, bot
         for r in range(rows):
             grid[r] = [" "] * cols
+        top, bot = 0, rows - 1                   # screen switch / RIS resets it
 
     while i < n:
         ch = text[i]
@@ -217,11 +260,47 @@ def _replay(data: bytes, cols: int, rows: int, trim: bool = True):
                 elif final == "F":  # CPL
                     y = max(y - (nums[0] or 1), 0)
                     x = 0
-                elif final == "J" and not priv:  # ED
+                elif final == "J":  # ED (and DECSED ?J: same erase — textgrid
+                    # models no selective-erase protection, so ?J behaves as J)
                     _erase_display(grid, x, y, cols, rows, nums[0] if nums else 0)
-                elif final == "K" and not priv:  # EL
+                elif final == "K":  # EL (and DECSEL ?K, same rationale)
                     _erase_line(grid[y], min(x, cols - 1), cols,
                                 nums[0] if nums else 0)
+                elif final == "r" and not priv:  # DECSTBM: set scroll region
+                    if not params:               # CSI r -> reset to full screen
+                        top, bot = 0, rows - 1    # (no cursor move, matches pyte)
+                    else:
+                        t0 = (nums[0] or 1) - 1
+                        b0 = (nums[1] if len(nums) > 1 and nums[1] > 0
+                              else rows) - 1
+                        if 0 <= t0 < b0 <= rows - 1:   # valid -> set + home
+                            top, bot = t0, b0
+                            x = y = 0
+                        # invalid (top>=bot): region & cursor unchanged (pyte)
+                elif final == "L" and top <= y <= bot:  # IL: insert blank lines
+                    for _ in range(min(nums[0] or 1, bot - y + 1)):
+                        grid.pop(bot)
+                        grid.insert(y, [" "] * cols)
+                    x = 0
+                elif final == "M" and top <= y <= bot:  # DL: delete lines
+                    for _ in range(min(nums[0] or 1, bot - y + 1)):
+                        grid.pop(y)
+                        grid.insert(bot, [" "] * cols)
+                    x = 0
+                elif final == "@":  # ICH: insert blanks, shift right (clip edge)
+                    cnt = min(nums[0] or 1, cols - x)
+                    grid[y][x:cols] = ([" "] * cnt + grid[y][x:cols])[:cols - x]
+                elif final == "P":  # DCH: delete chars, shift left, pad right
+                    cnt = min(nums[0] or 1, cols - x)
+                    grid[y][x:cols] = grid[y][x + cnt:cols] + [" "] * cnt
+                elif final == "X":  # ECH: erase n chars in place (no shift)
+                    cnt = min(nums[0] or 1, cols - x)
+                    for c in range(x, x + cnt):
+                        grid[y][c] = " "
+                elif final == "S":  # SU: scroll region up
+                    scroll_up(nums[0] or 1)
+                elif final == "T":  # SD: scroll region down
+                    scroll_down(nums[0] or 1)
                 # else: SGR ('m'), and anything else we don't model — discarded.
                 i = k + 1
                 continue
@@ -246,12 +325,11 @@ def _replay(data: bytes, cols: int, rows: int, trim: bool = True):
                 y = min(max(saved[1], 0), rows - 1)
                 i = j + 1
                 continue
-            if nxt == "M":  # RI: reverse index (up, scrolling down at the top)
-                if y > 0:
-                    y -= 1
+            if nxt == "M":  # RI: reverse index — up, or scroll region down at top
+                if y == top:
+                    scroll_down(1)
                 else:
-                    grid.pop()
-                    grid.insert(0, [" "] * cols)
+                    y = max(y - 1, 0)
                 i = j + 1
                 continue
             # Other two-byte escapes (= > D E ...): swallow the pair.
@@ -301,7 +379,8 @@ def render(data: bytes, cols: int, rows: int) -> str:
 
 
 def render_screen(data: bytes, cols: int, rows: int,
-                  view: str = "screen", lines: int = 0) -> Dict[str, Any]:
+                  view: str = "screen", lines: int = 0,
+                  evicted: bool = False) -> Dict[str, Any]:
     """Structured render for the MCP read (#21): ``{text, cursor, history_lines}``.
 
     ``view="screen"`` (default) returns just the current grid. ``view=
@@ -314,7 +393,8 @@ def render_screen(data: bytes, cols: int, rows: int,
     scrollback = view == "scrollback"
     # Scrollback replays the FULL ring (trim=False) so history before the last
     # clear/alt-enter survives; screen-only keeps the bounding trim.
-    grid, x, y, history = _replay(data, cols, rows, trim=not scrollback)
+    grid, x, y, history = _replay(data, cols, rows, trim=not scrollback,
+                                  evicted=evicted)
     screen = "\n".join("".join(r) for r in grid)
     cursor = {"row": min(max(int(y), 0), len(grid) - 1),
               "col": min(max(int(x), 0), cols_c - 1)}


### PR DESCRIPTION
Closes #28.

## What

The dependency-free `textgrid` emulator (the `read_screen` fallback when pyte is absent) ignored the VT/ECMA-48 ops a TUI uses to tear a menu down, so closed menus left **ghost glyphs** on the rendered grid:

- **DECSTBM** scroll regions (`CSI r`)
- **IL / DL** (`CSI L` / `CSI M`)
- **ICH / DCH / ECH** (`CSI @` / `CSI P` / `CSI X`)
- **SU / SD** (`CSI S` / `CSI T`)
- **private DECSED / DECSEL** (`CSI ?J` / `CSI ?K`) — previously fell through the `not priv` guard

All are now modeled, scroll-region-aware: scrolling, IL/DL and SU/SD act only within `[top, bot]` and leave rows outside the region fixed; `?J`/`?K` erase like `ED`/`EL` (textgrid models no selective-erase protection).

It also hardens the MCP screen render against an evicted ring head: the ring's `evicted` flag is threaded `_on_screen_request → _render_screen_text` so **both** the pyte and textgrid paths resync a truncated leading escape sequence to the first LF/ESC (mirroring `snapshot/raw._trim`) instead of mis-decoding it into top-left ghost glyphs.

## Testing

- **27 new tests** in `tests/test_textgrid.py`: every op that pyte itself dispatches (IL/DL/ICH/DCH/ECH/DECSTBM/`?J`/`?K`) is verified **byte-for-byte against pyte**; SU/SD (which pyte ignores) by direct grid assertions; plus the headline menu-teardown-leaves-no-ghost case, region-gating/edge clamps, and the evicted-head resync.
- Full suite green: **409 passed, 10 skipped**.
- End-to-end `read_screen` smoke against an isolated test broker confirms the MCP plumbing is intact (clean bounded grid, cursor, no degradation).

No change to behavior when the ring isn't evicted (`evicted` defaults `False`, identical to the prior marker-only trim).