### PR TITLE
feat(mcp): read_screen content_hash + wait-for-change (single round-trip polling)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -235,3 +235,85 @@ async def test_binary_from_broker_is_raw_input(running_agent, broker):
 async def _poll_until(predicate):
     while not predicate():
         await asyncio.sleep(0.02)
+
+
+# ---- #26: read_screen content_hash + wait-for-change ----------------------
+
+async def _read_screen(broker, req, **kw):
+    """Drive one screen_text_please RPC and return the matching screen_text."""
+    frame = {"type": "screen_text_please", "req": req, "view": "screen",
+             "lines": 0}
+    frame.update(kw)
+    await broker.send(frame)
+    return await broker.wait_text(
+        lambda f: f.get("type") == "screen_text" and f.get("req") == req)
+
+
+def test_content_hash_is_stable_and_sensitive():
+    from webterm.agent.agent import _content_hash
+    assert _content_hash("hello world") == _content_hash("hello world")
+    assert _content_hash("hello world") != _content_hash("hello worle")
+    assert len(_content_hash("x")) == 32          # blake2b digest_size=16
+
+
+async def test_read_screen_returns_content_hash(running_agent, broker):
+    _, backend, _ = running_agent
+    backend.feed(b"first screen\r\n")
+    await broker.wait_binary(lambda b: b"first screen" in b)
+    r1 = await _read_screen(broker, 1)
+    assert r1["content_hash"]                      # non-empty digest
+    assert "first screen" in r1["text"]
+    backend.feed(b"second screen\r\n")
+    await broker.wait_binary(lambda b: b"second screen" in b)
+    r2 = await _read_screen(broker, 2)
+    assert r2["content_hash"] != r1["content_hash"]   # changed -> new hash
+
+
+async def test_wait_for_change_returns_promptly_on_change(running_agent, broker):
+    _, backend, _ = running_agent
+    backend.feed(b"baseline\r\n")
+    await broker.wait_binary(lambda b: b"baseline" in b)
+    base = await _read_screen(broker, 1)
+    h0 = base["content_hash"]
+    # Park a wait on the baseline hash, let it settle, then change the screen.
+    waiter = asyncio.create_task(
+        _read_screen(broker, 2, wait_for_change=h0, timeout_ms=5000))
+    await asyncio.sleep(0.15)                       # let the agent render + park
+    assert not waiter.done()                        # still waiting (no change yet)
+    backend.feed(b"CHANGED!\r\n")
+    r = await asyncio.wait_for(waiter, 5)
+    assert r["content_hash"] != h0
+    assert "CHANGED!" in r["text"]
+
+
+async def test_wait_for_change_times_out_returns_current(running_agent, broker):
+    _, backend, _ = running_agent
+    backend.feed(b"static\r\n")
+    await broker.wait_binary(lambda b: b"static" in b)
+    base = await _read_screen(broker, 1)
+    h0 = base["content_hash"]
+    # No further output: the wait must return the current screen at timeout,
+    # not hang and not error.
+    loop = asyncio.get_running_loop()
+    t0 = loop.time()
+    r = await asyncio.wait_for(
+        _read_screen(broker, 2, wait_for_change=h0, timeout_ms=400), 5)
+    elapsed = loop.time() - t0
+    assert r["content_hash"] == h0                  # unchanged screen
+    assert "static" in r["text"]
+    assert elapsed >= 0.3                           # actually waited ~timeout_ms
+
+
+async def test_wait_for_change_clamps_huge_timeout(running_agent, broker):
+    # timeout_ms beyond the cap must not let the agent hold forever; with a
+    # change fed in, it still returns promptly (sanity that clamping is benign).
+    _, backend, _ = running_agent
+    backend.feed(b"start\r\n")
+    await broker.wait_binary(lambda b: b"start" in b)
+    h0 = (await _read_screen(broker, 1))["content_hash"]
+    waiter = asyncio.create_task(
+        _read_screen(broker, 2, wait_for_change=h0, timeout_ms=10**9))
+    await asyncio.sleep(0.1)
+    backend.feed(b"go\r\n")
+    r = await asyncio.wait_for(waiter, 5)
+    assert "go" in r["text"] and r["content_hash"] != h0

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -154,9 +154,27 @@ def test_mode_frame():
 def test_screen_text_please_frame_view_lines():
     f = json.loads(protocol.screen_text_please_frame(5, "scrollback", 200))
     assert f == {"type": "screen_text_please", "req": 5,
-                 "view": "scrollback", "lines": 200}
+                 "view": "scrollback", "lines": 200,
+                 "wait_for_change": None, "timeout_ms": 0}
     d = json.loads(protocol.screen_text_please_frame(5))
     assert d["view"] == "screen" and d["lines"] == 0
+    assert d["wait_for_change"] is None and d["timeout_ms"] == 0
+
+
+def test_screen_text_please_frame_wait_for_change():
+    # #26: a baseline hash + timeout ride the frame to the agent.
+    f = json.loads(protocol.screen_text_please_frame(
+        9, "screen", 0, wait_for_change="abc123", timeout_ms=3000))
+    assert f["wait_for_change"] == "abc123" and f["timeout_ms"] == 3000
+
+
+def test_screen_text_frame_content_hash():
+    # #26: content_hash rides the reply; default is the empty string.
+    f = json.loads(protocol.screen_text_frame(
+        7, "grid", 80, 24, content_hash="deadbeefcafef00d"))
+    assert f["content_hash"] == "deadbeefcafef00d"
+    assert json.loads(protocol.screen_text_frame(7, "g", 80, 24))[
+        "content_hash"] == ""
 
 
 def test_screen_text_frame_alt_cursor_view_fields():

--- a/webterm/agent/agent.py
+++ b/webterm/agent/agent.py
@@ -9,11 +9,12 @@ a snapshot enqueued between two PTY chunks is delivered between them.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import socket
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import List, Optional
 
 from .. import build_version, protocol
 from .altscreen import DecModeSniffer
@@ -31,6 +32,19 @@ LOGGER = logging.getLogger(__name__)
 # Foreground-agent detection cadence. A process-tree walk runs in a thread, so
 # this can be brisk without stalling the loop.
 _DETECT_INTERVAL = 1.5
+
+# read_screen wait-for-change cap (#26): the AGENT holds the reply for at most
+# this long, which also bounds how long one wait occupies a broker RPC slot
+# (RPC_MAX_INFLIGHT). The broker clamps the same ceiling.
+MAX_WAIT_MS = 15000
+
+
+def _content_hash(text: str) -> str:
+    """A stable, process-independent digest of the rendered screen text, so a
+    caller can detect change across reads without diffing full text (#26). 128
+    bits — small on the wire, collision-safe for change detection."""
+    return hashlib.blake2b(text.encode("utf-8", "replace"),
+                           digest_size=16).hexdigest()
 
 
 def _render_screen_text(data: bytes, cols: int, rows: int,
@@ -159,6 +173,13 @@ class Agent:
             on_screen_request=self._on_screen_request,
         )
         self._exit_fut: Optional[asyncio.Future] = None
+        # read_screen wait-for-change (#26): a monotonic counter bumped on every
+        # PTY append, plus the futures of reads currently parked waiting for the
+        # next output. The counter is the source of truth (a parked read that
+        # snapshotted before an append sees gen advance and re-renders), so no
+        # shared Event/clear can swallow a wakeup across concurrent waiters.
+        self._output_gen = 0
+        self._output_waiters: List[asyncio.Future] = []
 
     async def run(self) -> int:
         """Run until the child exits; returns the child's exit code."""
@@ -210,6 +231,16 @@ class Agent:
 
     def _on_pty_data(self, chunk: bytes) -> None:
         self.ring.append(chunk)
+        # Wake any read_screen waiting for the screen to change (#26). Bump the
+        # generation first (so a waiter that already snapshotted re-renders even
+        # if it hasn't parked yet), then resolve every parked future. Runs on
+        # the loop, so this is atomic vs a waiter's gen-check-then-park.
+        self._output_gen += 1
+        if self._output_waiters:
+            waiters, self._output_waiters = self._output_waiters, []
+            for fut in waiters:
+                if not fut.done():
+                    fut.set_result(None)
         # Track DEC modes live (#21/#23): survives ring eviction, unlike a re-scan.
         self._mode_sniffer.feed(chunk)
         self.state.alt_screen = self._mode_sniffer.alt_screen
@@ -375,37 +406,78 @@ class Agent:
         loop.create_task(_run())
 
     def _on_screen_request(self, req: int, view: str = "screen",
-                           lines: int = 0) -> None:
-        # MCP /mcp/read: render the live screen as plain text. Snapshot the
-        # ring + dims + live alt-screen state synchronously on the loop
-        # (consistent view), then render off-loop (pyte can be CPU-heavy on a
-        # large ring) and enqueue the reply on the SAME ordered out-queue.
+                           lines: int = 0,
+                           wait_for_change: Optional[str] = None,
+                           timeout_ms: int = 0) -> None:
+        # MCP /mcp/read: render the live screen as plain text. Each render
+        # snapshots the ring + dims + live alt-screen state synchronously on the
+        # loop (an immutable, consistent view), then renders off-loop (pyte can
+        # be CPU-heavy on a large ring) and enqueues the reply on the SAME
+        # ordered out-queue. With wait_for_change (#26) it re-renders on each
+        # PTY-output nudge until the screen hash differs from the baseline or
+        # timeout_ms elapses — one round-trip instead of an agent busy-poll.
         loop = asyncio.get_running_loop()
-        data = self.ring.get()
-        evicted = self.ring.evicted              # head may start mid-seq (#28)
-        cols, rows = self.state.cols, self.state.rows
-        alt = self.state.alt_screen
-        app_cursor = self.state.app_cursor       # DECCKM (#23)
+
+        async def _render() -> dict:
+            # Snapshot on the loop (ring.get() returns immutable bytes) so the
+            # executor never walks the live deque; re-read dims/alt each pass.
+            data = self.ring.get()
+            evicted = self.ring.evicted          # head may start mid-seq (#28)
+            cols, rows = self.state.cols, self.state.rows
+            r = await loop.run_in_executor(
+                None, _render_screen_text, data, cols, rows, view, lines,
+                self.state.alt_screen, evicted)
+            r["cols"], r["rows"] = cols, rows
+            return r
+
+        def _reply(r: dict, content_hash: str) -> None:
+            self._enqueue("txt", protocol.screen_text_frame(
+                req, r["text"], r["cols"], r["rows"], degraded=r["degraded"],
+                alt_screen=r["alt_screen"], cursor=r["cursor"],
+                view=r["view"], history_lines=r["history_lines"],
+                app_cursor=self.state.app_cursor, content_hash=content_hash))
 
         async def _run() -> None:
             try:
-                r = await loop.run_in_executor(
-                    None, _render_screen_text, data, cols, rows, view, lines,
-                    alt, evicted)
-                self._enqueue("txt", protocol.screen_text_frame(
-                    req, r["text"], cols, rows, degraded=r["degraded"],
-                    alt_screen=r["alt_screen"], cursor=r["cursor"],
-                    view=r["view"], history_lines=r["history_lines"],
-                    app_cursor=app_cursor))
+                wait_ms = max(0, min(int(timeout_ms or 0), MAX_WAIT_MS))
+                deadline = loop.time() + wait_ms / 1000.0
+                while True:
+                    observed = self._output_gen
+                    r = await _render()
+                    h = _content_hash(r["text"])
+                    timed_out = loop.time() >= deadline
+                    if not wait_for_change or h != wait_for_change or timed_out:
+                        _reply(r, h)
+                        return
+                    # New output during the render? Re-render before parking.
+                    if self._output_gen != observed:
+                        continue
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        continue                 # deadline -> reply next pass
+                    # No await between the gen-check above and this append, so
+                    # _on_pty_data can't slip a nudge past us (loop atomicity).
+                    fut = loop.create_future()
+                    self._output_waiters.append(fut)
+                    try:
+                        await asyncio.wait_for(fut, timeout=remaining)
+                    except asyncio.TimeoutError:
+                        pass                     # deadline -> reply next pass
+                    finally:
+                        try:
+                            self._output_waiters.remove(fut)
+                        except ValueError:
+                            pass                 # drained by _on_pty_data
             except Exception as exc:
                 # Always answer the RPC — an unhandled failure here would leave
                 # the broker waiting until it times out (no_producer_rpc).
                 LOGGER.warning("screen_text request failed (%s); degraded reply",
                                exc)
                 self._enqueue("txt", protocol.screen_text_frame(
-                    req, "", cols, rows, degraded=True, alt_screen=alt,
-                    cursor=None, view="raw", history_lines=0,
-                    app_cursor=app_cursor))
+                    req, "", self.state.cols, self.state.rows, degraded=True,
+                    alt_screen=self.state.alt_screen, cursor=None, view="raw",
+                    history_lines=0, app_cursor=self.state.app_cursor,
+                    content_hash=""))
 
         loop.create_task(_run())
 

--- a/webterm/agent/client.py
+++ b/webterm/agent/client.py
@@ -210,11 +210,16 @@ class BrokerClient:
                     self._on_git_request(_int(data.get("req"), -1))
             elif mtype == "screen_text_please":
                 if self._on_screen_request is not None:
-                    # view/lines drive scrollback (#21); absent for older brokers.
+                    # view/lines drive scrollback (#21); wait_for_change/
+                    # timeout_ms drive wait-for-change (#26). All absent for
+                    # older brokers -> defaults give an immediate single read.
+                    wfc = data.get("wait_for_change")
                     self._on_screen_request(
                         _int(data.get("req"), -1),
                         str(data.get("view", "screen") or "screen"),
-                        _int(data.get("lines"), 0))
+                        _int(data.get("lines"), 0),
+                        wfc if isinstance(wfc, str) and wfc else None,
+                        _int(data.get("timeout_ms"), 0))
             else:
                 LOGGER.debug("unknown broker frame type %r", mtype)
 

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -77,6 +77,12 @@ MCP_MODES = ("off", "read", "readwrite")
 # enqueueing an unbounded write to the PTY. Generous vs any real input.
 MAX_MCP_INPUT_BYTES = 256 * 1024
 
+# /mcp/read wait-for-change (#26): cap how long the agent may hold a read while
+# waiting for the screen to change. This also bounds how long one waiting read
+# occupies a per-session RPC slot (RPC_MAX_INFLIGHT); the agent clamps to the
+# same ceiling.
+MAX_MCP_WAIT_MS = 15000
+
 
 def _norm_mcp_mode(value: Any, default: str = "off") -> str:
     """Coerce an arbitrary value to a valid MCP mode, else ``default``."""
@@ -864,17 +870,19 @@ def create_app(config: Optional[Dict[str, Any]] = None,
     # gate as /launch — killing processes is privileged. The agent scopes kills
     # to the session's own process tree; the broker never trusts a client pid
     # beyond relaying it.
-    async def _session_rpc(entry, make_frame, expected: str):
+    async def _session_rpc(entry, make_frame, expected: str,
+                           timeout: float = RPC_TIMEOUT):
         """Park a Future on the producer entry, send the request frame, await
         the matching reply. Returns ``(payload, error)`` where error is one of
-        None / "busy" / "timeout" / "gone"."""
+        None / "busy" / "timeout" / "gone". ``timeout`` is extended for a
+        read_screen wait-for-change so the RPC outlives the agent's wait (#26)."""
         allocated = entry.new_rpc(expected)
         if allocated is None:
             return None, "busy"          # too many in flight on this session
         req, future = allocated
         try:
             await entry.send_to_producer(make_frame(req))
-            payload = await asyncio.wait_for(future, timeout=RPC_TIMEOUT)
+            payload = await asyncio.wait_for(future, timeout=timeout)
             return payload, None
         except asyncio.TimeoutError:
             return None, "timeout"
@@ -1080,10 +1088,27 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         except (TypeError, ValueError):
             lines = 0
         lines = max(0, min(lines, 1000))
+        # wait-for-change (#26): a prior content_hash + a timeout. The agent
+        # holds the reply until the screen hash differs or timeout_ms elapses;
+        # extend the RPC timeout to outlive that wait (plus RPC_TIMEOUT of slack
+        # for dispatch + the final render). Without a baseline hash this is a
+        # plain immediate read on the default timeout.
+        wait_for_change = body.get("wait_for_change")
+        if not isinstance(wait_for_change, str) or not wait_for_change:
+            wait_for_change = None
+        try:
+            timeout_ms = int(body.get("timeout_ms", 0) or 0)
+        except (TypeError, ValueError):
+            timeout_ms = 0
+        timeout_ms = max(0, min(timeout_ms, MAX_MCP_WAIT_MS))
+        rpc_timeout = RPC_TIMEOUT
+        if wait_for_change:
+            rpc_timeout = RPC_TIMEOUT + timeout_ms / 1000.0
         payload, error = await _session_rpc(
             entry,
-            lambda req: protocol.screen_text_please_frame(req, view, lines),
-            "screen_text")
+            lambda req: protocol.screen_text_please_frame(
+                req, view, lines, wait_for_change, timeout_ms),
+            "screen_text", timeout=rpc_timeout)
         if error is not None:
             return sanic_json({"error": "no_producer_rpc"}, status=502)
         payload = payload or {}
@@ -1091,11 +1116,12 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                "cols": payload.get("cols", entry.cols),
                "rows": payload.get("rows", entry.rows),
                "text": payload.get("text", ""),
-               # New fields (#21/#23); older agents omit them -> these defaults.
+               # New fields (#21/#23/#26); older agents omit them -> defaults.
                "alt_screen": bool(payload.get("alt_screen", False)),
                "app_cursor": bool(payload.get("app_cursor", False)),
                "view": payload.get("view", "screen"),
                "history_lines": int(payload.get("history_lines", 0) or 0),
+               "content_hash": str(payload.get("content_hash", "") or ""),
                "cursor": payload.get("cursor")}
         if payload.get("degraded"):
             out["degraded"] = True

--- a/webterm/mcptool/client.py
+++ b/webterm/mcptool/client.py
@@ -140,16 +140,28 @@ class BrowserlandClient:
         """Launchable profile names + the broker default."""
         return self._get("/mcp/profiles")
 
-    def read_screen(self, id: int, view: str = "screen",
-                    lines: int = 0) -> Dict[str, Any]:
+    def read_screen(self, id: int, view: str = "screen", lines: int = 0,
+                    wait_for_change: Optional[str] = None,
+                    timeout_ms: int = 0) -> Dict[str, Any]:
         """Render a terminal's screen as plain text. ``view="scrollback"`` with
-        ``lines>0`` prepends that many lines of history above the grid (#21)."""
+        ``lines>0`` prepends that many lines of history above the grid (#21).
+
+        ``wait_for_change`` (a prior ``content_hash``) + ``timeout_ms`` hold the
+        read until the screen changes or the timeout elapses (#26). The HTTP
+        read timeout is stretched past the broker's wait so the request doesn't
+        give up before the broker answers."""
         body: Dict[str, Any] = {"id": id}
         if view and view != "screen":
             body["view"] = view
         if lines:
             body["lines"] = lines
-        return self._post("/mcp/read", body, timeout=self._read_timeout)
+        req_timeout = self._read_timeout
+        if wait_for_change:
+            body["wait_for_change"] = wait_for_change
+            if timeout_ms:
+                body["timeout_ms"] = int(timeout_ms)
+                req_timeout = self._read_timeout + int(timeout_ms) / 1000.0
+        return self._post("/mcp/read", body, timeout=req_timeout)
 
     def send_input(self, id: int, data: str) -> Dict[str, Any]:
         r"""Type into a terminal. Requires the window be in ``readwrite`` mode.

--- a/webterm/mcptool/server.py
+++ b/webterm/mcptool/server.py
@@ -318,17 +318,30 @@ def list_profiles(host: Optional[str] = None) -> Dict[str, Any]:
 
 
 @mcp.tool()
-def read_screen(id: str, view: str = "screen", lines: int = 0) -> Dict[str, Any]:
+def read_screen(id: str, view: str = "screen", lines: int = 0,
+                wait_for_change: str = "", timeout_ms: int = 0) -> Dict[str, Any]:
     """Render a terminal's current screen as plain text. Pass a namespaced window
     id ("<host>:<int>") from list_terminals.
 
-    The result includes `alt_screen` (true for a full-screen TUI like mc/btop/
-    vim — the grid is the whole story, so scrollback is meaningless) and
-    `cursor` {row, col}. For a shell, pass `view="scrollback"` with `lines=N` to
-    get up to N lines of history above the current grid (`history_lines` reports
-    how many were included; ignored when `alt_screen` is true)."""
+    The result includes `content_hash` (a stable digest of the screen text),
+    `alt_screen` (true for a full-screen TUI like mc/btop/vim — the grid is the
+    whole story, so scrollback is meaningless) and `cursor` {row, col}. For a
+    shell, pass `view="scrollback"` with `lines=N` to get up to N lines of
+    history above the current grid (`history_lines` reports how many were
+    included; ignored when `alt_screen` is true).
+
+    To wait for the screen to change after an action in ONE call instead of
+    polling, pass the previous read's `content_hash` as `wait_for_change` plus a
+    `timeout_ms` (capped at 15000): the read blocks until the screen differs from
+    that hash and returns the new screen — or returns the current screen if the
+    timeout elapses first. Typical use:
+        send_keys(id, ["Down"])
+        read_screen(id, wait_for_change=prev_hash, timeout_ms=3000)
+    Omit `wait_for_change` for an immediate read."""
     client, int_id = _route(id)
-    return client.read_screen(int_id, view=view, lines=lines)
+    return client.read_screen(int_id, view=view, lines=lines,
+                              wait_for_change=wait_for_change or None,
+                              timeout_ms=timeout_ms)
 
 
 @mcp.tool()

--- a/webterm/protocol.py
+++ b/webterm/protocol.py
@@ -156,14 +156,23 @@ def procs_please_frame(req: int) -> str:
 
 
 def screen_text_please_frame(req: int, view: str = "screen",
-                             lines: int = 0) -> str:
+                             lines: int = 0,
+                             wait_for_change: Optional[str] = None,
+                             timeout_ms: int = 0) -> str:
     """Broker -> producer: render the live screen and reply with plain text.
     Backs the MCP /mcp/read endpoint; only agents answer it (non-agent
     producers have no handler, so the request times out -> 502). ``view``
     (``"screen"`` default / ``"scrollback"``) + ``lines`` request scrollback
-    history above the current grid (#21); older agents ignore the extra keys."""
+    history above the current grid (#21); older agents ignore the extra keys.
+
+    ``wait_for_change`` (a prior ``content_hash``) + ``timeout_ms`` make the
+    AGENT hold the reply until the freshly-rendered screen hash differs from
+    that baseline, or the timeout elapses — a single round-trip instead of a
+    busy-poll (#26). Older agents ignore both and reply immediately."""
     return json.dumps({"type": "screen_text_please", "req": int(req),
-                       "view": str(view), "lines": int(lines)})
+                       "view": str(view), "lines": int(lines),
+                       "wait_for_change": wait_for_change,
+                       "timeout_ms": int(timeout_ms)})
 
 
 def kill_frame(req: int, pid: int) -> str:
@@ -200,7 +209,7 @@ def screen_text_frame(req: int, text: str, cols: int, rows: int,
                       degraded: bool = False, alt_screen: bool = False,
                       cursor: Optional[Dict[str, int]] = None,
                       view: str = "screen", history_lines: int = 0,
-                      app_cursor: bool = False) -> str:
+                      app_cursor: bool = False, content_hash: str = "") -> str:
     """Producer -> broker: the rendered plain-text screen for a screen_text
     request. ``text`` is a bounded ``rows``x``cols`` grid (plus ``history_lines``
     of scrollback above it when ``view="scrollback"``), rendered via pyte or the
@@ -209,6 +218,8 @@ def screen_text_frame(req: int, text: str, cols: int, rows: int,
     is meaningless and ``view`` comes back ``"screen"``. ``app_cursor`` (#23) is
     DECCKM (application cursor keys) — when true, send_keys must emit SS3 arrows.
     ``cursor`` is ``{row, col}`` 0-based within the grid (``None`` when degraded).
+    ``content_hash`` (#26) is a stable digest of ``text`` so a caller can detect
+    change across reads (the empty string means the agent didn't compute one).
     ``degraded`` is the rare last-ditch raw decode (``view="raw"``), so the
     caller knows the text is not a clean grid render."""
     frame: Dict[str, Any] = {
@@ -222,6 +233,7 @@ def screen_text_frame(req: int, text: str, cols: int, rows: int,
         "app_cursor": bool(app_cursor),
         "view": str(view),
         "history_lines": int(history_lines),
+        "content_hash": str(content_hash),
     }
     # cursor is null on the degraded raw path (no grid to locate it in) — the
     # helper enforces the invariant regardless of what the caller passed.


### PR DESCRIPTION
Closes #26.

## Problem

`read_screen` always returned immediately, so an agent had to busy-poll (`send_keys` → `read_screen` → `send_keys` → …) to detect when a slow TUI's screen settled — 30+ `read_screen` calls per action, burning tokens.

## Design (agent-centric — the broker stays a thin relay)

**Part 1 — `content_hash`:** the agent already renders the full screen per read; it now hashes that text (blake2b, 128-bit, stable across processes) and returns it as `content_hash`. Agents compare hashes across calls to detect change without diffing.

**Part 2 — `wait_for_change` + `timeout_ms`:** with a baseline hash supplied, the **agent** holds the reply and re-renders on each PTY-output nudge, replying once the freshly-rendered hash differs from the baseline — or `timeout_ms` elapses (then it replies with the current screen). Net: one round-trip.
```
send_keys(id, ["Down"])
read_screen(id, wait_for_change=prev_hash, timeout_ms=3000)
```

## Concurrency

The wake-up uses a **monotonic output-generation counter + per-waiter futures**, not a shared `Event.clear()` — so concurrent waiters can't swallow each other's wakeups, and an append that lands *during* a render is caught by the gen-check (no lost update). The ring is snapshotted on the loop (immutable bytes) and rendered off-loop, so the executor never walks the live deque.

The broker extends its RPC timeout to outlive the wait (clamped to **15s**, which also bounds how long a waiting read holds one of the `RPC_MAX_INFLIGHT` slots); the mcptool client stretches its HTTP read timeout past the broker's wait.

## Compat

Every new field defaults off, so an old agent/broker/mcptool on either end degrades cleanly to an immediate read (an old agent ignores the wait keys and replies at once; an old broker drops `content_hash`).

## Testing

- New unit/integration tests: protocol frame round-trips, `_content_hash` stability/sensitivity, and against the fake-broker+scripted-backend harness — `content_hash` changes with the screen, **wakeup-on-change** returns promptly, the **timeout path** returns the current screen after ~`timeout_ms`, and a huge `timeout_ms` is clamped.
- Full suite green: **416 passed, 10 skipped**.
- End-to-end over real MCP HTTP on an isolated test broker: `wait_for_change` returned in **0.44s** on a change (vs a 6s timeout) and at **0.70s** for `timeout_ms=700`.

Reply-on-change (not a settle debounce) is the issue's explicit spec; an optional `settle_ms` is noted as possible future work.