### PR TITLE
feat(mcp): reset_terminal tool + Ctrl-L recovery docs (#27)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -317,3 +317,53 @@ async def test_wait_for_change_clamps_huge_timeout(running_agent, broker):
     backend.feed(b"go\r\n")
     r = await asyncio.wait_for(waiter, 5)
     assert "go" in r["text"] and r["content_hash"] != h0
+
+
+# ---- #27: reset_terminal clears the agent's render buffer -----------------
+
+async def _reset(broker, req):
+    """Drive one reset_please RPC and return the matching reset_done."""
+    await broker.send({"type": "reset_please", "req": req})
+    return await broker.wait_text(
+        lambda f: f.get("type") == "reset_done" and f.get("req") == req)
+
+
+async def test_reset_clears_ring_and_acks(running_agent, broker):
+    agent, backend, _ = running_agent
+    # Two chunks past the 4096-byte ring force an eviction (evicted=True), so
+    # the reset must also clear that flag for a clean-slate next render.
+    backend.feed(b"A" * 3000)
+    backend.feed(b"some screen content here\r\n" + b"B" * 3000)
+    await broker.wait_binary(lambda b: b"some screen content" in b)
+    await asyncio.wait_for(_poll_until(lambda: agent.ring.evicted), 5)
+    assert len(agent.ring) > 0
+    gen_before = agent._output_gen
+
+    done = await _reset(broker, 2)
+    assert done["ok"] is True
+    assert len(agent.ring) == 0                 # ring emptied
+    assert agent.ring.evicted is False          # evicted flag reset
+    assert agent._output_gen > gen_before       # waiters were woken
+
+    # Next read renders a blank grid — the prior content is gone, but the
+    # reply is still well-formed (bounded grid + a content_hash, #26).
+    r = await _read_screen(broker, 3)
+    assert "some screen content" not in r["text"]
+    assert r["text"].strip() == ""
+    assert r["content_hash"]
+
+
+async def test_reset_wakes_wait_for_change(running_agent, broker):
+    # A parked wait-for-change must wake when the screen is reset to blank.
+    agent, backend, _ = running_agent
+    backend.feed(b"before reset\r\n")
+    await broker.wait_binary(lambda b: b"before reset" in b)
+    h0 = (await _read_screen(broker, 1))["content_hash"]
+    waiter = asyncio.create_task(
+        _read_screen(broker, 2, wait_for_change=h0, timeout_ms=5000))
+    await asyncio.sleep(0.15)
+    assert not waiter.done()
+    await _reset(broker, 3)
+    r = await asyncio.wait_for(waiter, 5)
+    assert r["content_hash"] != h0
+    assert "before reset" not in r["text"]

--- a/tests/test_mcptool.py
+++ b/tests/test_mcptool.py
@@ -164,6 +164,23 @@ def test_send_input_posts_id_and_data():
     assert out == {"ok": True}
 
 
+def test_reset_terminal_posts_id():
+    # #27: reset_terminal is a thin POST /mcp/reset {id} that clears the
+    # agent's render buffer; the broker enforces readwrite, not the client.
+    seen = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["path"] = req.url.path
+        seen["body"] = json.loads(req.content)
+        return httpx.Response(200, json={"ok": True})
+
+    with _client(handler) as c:
+        out = c.reset_terminal(42)
+    assert seen["path"] == "/mcp/reset"
+    assert seen["body"] == {"id": 42}
+    assert out == {"ok": True}
+
+
 # ---- #13: MCP tool maps newlines -> Enter (CR); client stays verbatim -----
 
 @pytest.mark.parametrize("data,expected", [
@@ -995,7 +1012,8 @@ async def test_tools_registered():
     tools = await server.mcp.list_tools()
     names = sorted(t.name for t in tools)
     assert names == ["launch_terminal", "list_profiles", "list_terminals",
-                     "mcp_info", "read_screen", "send_input", "send_keys"]
+                     "mcp_info", "read_screen", "reset_terminal", "send_input",
+                     "send_keys"]
 
 
 def test_tools_round_trip_through_http():

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -108,6 +108,8 @@ def test_management_rpc_request_frames():
         "type": "kill", "req": 7, "pid": 4321}
     assert json.loads(protocol.git_status_please_frame(9)) == {
         "type": "git_status_please", "req": 9}
+    assert json.loads(protocol.reset_please_frame(11)) == {
+        "type": "reset_please", "req": 11}
 
 
 def test_management_rpc_reply_frames():
@@ -126,6 +128,11 @@ def test_management_rpc_reply_frames():
         3, {"ok": True, "branch": "main", "dirty": False}))
     assert frame["type"] == "git_status" and frame["req"] == 3
     assert frame["branch"] == "main" and frame["ok"] is True
+    # reset_done (#27): error only present when supplied.
+    assert json.loads(protocol.reset_done_frame(11, True)) == {
+        "type": "reset_done", "req": 11, "ok": True}
+    assert json.loads(protocol.reset_done_frame(11, False, error="boom")) == {
+        "type": "reset_done", "req": 11, "ok": False, "error": "boom"}
 
 
 def test_parse_round_trip():

--- a/webterm/agent/agent.py
+++ b/webterm/agent/agent.py
@@ -171,6 +171,7 @@ class Agent:
             on_kill_request=self._on_kill_request,
             on_git_request=self._on_git_request,
             on_screen_request=self._on_screen_request,
+            on_reset_request=self._on_reset_request,
         )
         self._exit_fut: Optional[asyncio.Future] = None
         # read_screen wait-for-change (#26): a monotonic counter bumped on every
@@ -229,18 +230,22 @@ class Agent:
 
     # -- PTY -> broker (called on the loop by the backend) -------------------
 
-    def _on_pty_data(self, chunk: bytes) -> None:
-        self.ring.append(chunk)
-        # Wake any read_screen waiting for the screen to change (#26). Bump the
-        # generation first (so a waiter that already snapshotted re-renders even
-        # if it hasn't parked yet), then resolve every parked future. Runs on
-        # the loop, so this is atomic vs a waiter's gen-check-then-park.
+    def _wake_output_waiters(self) -> None:
+        # A screen-affecting event (new PTY output, or a reset_terminal): bump
+        # the change generation FIRST — so a read that already snapshotted but
+        # hasn't parked re-renders rather than missing it — then resolve every
+        # parked wait_for_change future (#26). Always called on the loop, so it
+        # is atomic vs a waiter's gen-check-then-park.
         self._output_gen += 1
         if self._output_waiters:
             waiters, self._output_waiters = self._output_waiters, []
             for fut in waiters:
                 if not fut.done():
                     fut.set_result(None)
+
+    def _on_pty_data(self, chunk: bytes) -> None:
+        self.ring.append(chunk)
+        self._wake_output_waiters()              # wake read_screen waiters (#26)
         # Track DEC modes live (#21/#23): survives ring eviction, unlike a re-scan.
         self._mode_sniffer.feed(chunk)
         self.state.alt_screen = self._mode_sniffer.alt_screen
@@ -389,6 +394,23 @@ class Agent:
                                                         pid=pid))
 
         loop.create_task(_run())
+
+    def _on_reset_request(self, req: int) -> None:
+        # MCP reset_terminal (#27): wipe Browserland's PTY-output ring so the
+        # next read_screen (and any reconnecting browser's snapshot) renders
+        # from a clean slate — independent of what the app does, since the
+        # renderer reads the ring, not the app's stdin. Clearing also resets the
+        # ring's evicted flag (an empty head can't be a cut escape sequence).
+        # The app's live alt-screen / DECCKM state is sniffed off the byte
+        # stream, not the ring, so it is intentionally left intact. Handled
+        # inline on the loop — ByteRing.clear() is O(1), never blocking.
+        try:
+            self.ring.clear()
+            self._wake_output_waiters()      # a parked wait_for_change re-renders
+            ok, err = True, None
+        except Exception as exc:
+            ok, err = False, str(exc)[:200]
+        self._enqueue("txt", protocol.reset_done_frame(req, ok, error=err))
 
     def _on_git_request(self, req: int) -> None:
         loop = asyncio.get_running_loop()

--- a/webterm/agent/client.py
+++ b/webterm/agent/client.py
@@ -58,6 +58,7 @@ class BrokerClient:
         on_kill_request: Optional[Callable[[int, int], None]] = None,
         on_git_request: Optional[Callable[[int], None]] = None,
         on_screen_request: Optional[Callable[..., None]] = None,
+        on_reset_request: Optional[Callable[[int], None]] = None,
     ) -> None:
         self._url = url
         self._token = token
@@ -70,6 +71,7 @@ class BrokerClient:
         self._on_kill_request = on_kill_request
         self._on_git_request = on_git_request
         self._on_screen_request = on_screen_request
+        self._on_reset_request = on_reset_request
         self.connected = False
         self._stopping = False
         self._stop_event: Optional[asyncio.Event] = None
@@ -205,6 +207,9 @@ class BrokerClient:
                 if self._on_kill_request is not None:
                     self._on_kill_request(_int(data.get("req"), -1),
                                           _int(data.get("pid"), 0))
+            elif mtype == "reset_please":
+                if self._on_reset_request is not None:
+                    self._on_reset_request(_int(data.get("req"), -1))
             elif mtype == "git_status_please":
                 if self._on_git_request is not None:
                     self._on_git_request(_int(data.get("req"), -1))

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -1148,6 +1148,31 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         await entry.send_to_producer(protocol.input_frame(data))
         return sanic_json({"ok": True})
 
+    async def _mcp_reset(request: Request):
+        # #27: clear the producer's screen-render buffer (its PTY-output ring)
+        # so the next read_screen renders from a clean slate. A mutating
+        # terminal-management action (it discards observable history for every
+        # viewer), so it needs readwrite — like /mcp/input. Same correlated
+        # round-trip as /mcp/read: only an agent answers, so a non-agent
+        # producer times out -> 502 no_producer_rpc.
+        err = _mcp_auth_error(request)
+        if err is not None:
+            return err
+        entry, mode, resp = _mcp_entry(request)
+        if resp is not None:
+            return resp
+        if mode != "readwrite":
+            return sanic_json({"error": "read_only"}, status=403)
+        payload, error = await _session_rpc(
+            entry, lambda req: protocol.reset_please_frame(req), "reset_done")
+        if error is not None:
+            return sanic_json({"error": "no_producer_rpc"}, status=502)
+        payload = payload or {}
+        if not payload.get("ok"):
+            return sanic_json({"error": "reset_failed",
+                               "detail": payload.get("error")}, status=502)
+        return sanic_json({"ok": True, "id": entry.id})
+
     async def _mcp_profiles(request: Request):
         err = _mcp_auth_error(request)
         if err is not None:
@@ -1345,6 +1370,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
     app.add_route(_mcp_terminals, "/mcp/terminals", methods=["GET"])
     app.add_route(_mcp_read, "/mcp/read", methods=["POST"])
     app.add_route(_mcp_input, "/mcp/input", methods=["POST"])
+    app.add_route(_mcp_reset, "/mcp/reset", methods=["POST"])
     app.add_route(_mcp_profiles, "/mcp/profiles", methods=["GET"])
     app.add_route(_mcp_launch, "/mcp/launch", methods=["POST"])
     app.add_route(_mcp_config_get, "/mcp/config", methods=["GET"])
@@ -1368,6 +1394,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                              ("/mcp/terminals", "preflight_mcp_terminals"),
                              ("/mcp/read", "preflight_mcp_read"),
                              ("/mcp/input", "preflight_mcp_input"),
+                             ("/mcp/reset", "preflight_mcp_reset"),
                              ("/mcp/profiles", "preflight_mcp_profiles"),
                              ("/mcp/launch", "preflight_mcp_launch"),
                              ("/mcp/config", "preflight_mcp_config")):

--- a/webterm/broker/registry.py
+++ b/webterm/broker/registry.py
@@ -413,7 +413,8 @@ async def run_producer_session(ws, registry: BrokerRegistry) -> None:
                 await entry.broadcast_text(protocol.exit_frame(_code(data)))
                 await registry.deregister(entry.id, entry)
                 break
-            elif mtype in ("procs", "killed", "git_status", "screen_text"):
+            elif mtype in ("procs", "killed", "git_status", "screen_text",
+                           "reset_done"):
                 # Management-RPC replies: resolve the matching pending request
                 # on THIS entry only. _req() tolerates a missing/garbled id by
                 # mapping to -1, which simply never matches a live request.

--- a/webterm/mcptool/client.py
+++ b/webterm/mcptool/client.py
@@ -172,6 +172,12 @@ class BrowserlandClient:
         submit on PowerShell must pass ``\r`` itself (see issue #13)."""
         return self._post("/mcp/input", {"id": id, "data": data})
 
+    def reset_terminal(self, id: int) -> Dict[str, Any]:
+        """Clear a terminal's screen-render buffer (#27). Requires ``readwrite``
+        mode. Wipes the agent's PTY-output ring so the next ``read_screen``
+        starts from a clean slate; does not touch the running app."""
+        return self._post("/mcp/reset", {"id": id})
+
     def launch_terminal(self, profile: Optional[str] = None, cols: int = 80,
                         rows: int = 24, title: Optional[str] = None,
                         cwd: Optional[str] = None) -> Dict[str, Any]:

--- a/webterm/mcptool/server.py
+++ b/webterm/mcptool/server.py
@@ -358,7 +358,11 @@ def send_input(id: str, data: str) -> Dict[str, Any]:
     continuation. Any control/escape bytes already in `data` pass through
     unchanged. The single thing this tool can't express is a literal line-feed
     byte (`\n` is remapped to Enter); for that rare case, drive the broker's
-    `POST /mcp/input` endpoint directly."""
+    `POST /mcp/input` endpoint directly.
+
+    If read_screen looks corrupted, this tool can't fix it — bytes in `data`
+    reach the app, not Browserland's renderer. Send `send_keys(id, ["C-l"])` to
+    redraw a live app, or `reset_terminal(id)` to wipe the screen buffer."""
     client, int_id = _route(id)
     return client.send_input(int_id, _newlines_to_enter(data))
 
@@ -386,8 +390,16 @@ def send_keys(id: str, keys: List[str]) -> Dict[str, Any]:
     — best-effort from the agent's cached DECCKM, so arrows work in those TUIs
     without hand-assembling escapes (#23); it falls back to CSI for a non-agent
     producer or if the state can't be read. Tokens are sent verbatim (no
-    newline->Enter rewrite); use `send_input` for ordinary text. Pass a
-    namespaced window id ("<host>:<int>")."""
+    newline->Enter rewrite); use `send_input` for ordinary text.
+
+    Recovery: if read_screen shows ghost text or a corrupted screen but the app
+    is still responding, send `["C-l"]` (Ctrl-L) to make the app repaint — that
+    fresh output is what the renderer reads. A raw reset sequence sent as input
+    is just keystrokes to the app and does NOT reset Browserland's own screen
+    render; to wipe a corrupted buffer regardless of the app, use
+    `reset_terminal`. (Neither un-freezes a hung app — kill it.)
+
+    Pass a namespaced window id ("<host>:<int>")."""
     # Validate + translate up front (atomic, CSI form): a bad token raises here,
     # before any routing, DECCKM lookup or send.
     text = _keys_to_text(keys)
@@ -395,6 +407,24 @@ def send_keys(id: str, keys: List[str]) -> Dict[str, Any]:
     if _keys_have_cursor(keys) and _terminal_app_cursor(client, int_id):
         text = _keys_to_text(keys, app_cursor=True)   # re-encode arrows as SS3
     return client.send_input(int_id, text)
+
+
+@mcp.tool()
+def reset_terminal(id: str) -> Dict[str, Any]:
+    """Wipe Browserland's screen buffer for a terminal so read_screen renders
+    from a clean slate. Pass a namespaced window id ("<host>:<int>"); the window
+    must be in 'readwrite' mode.
+
+    Use this when read_screen shows accumulated ghost text / corruption that a
+    redraw won't clear: it empties the agent's PTY-output ring — the buffer the
+    screen renderer actually reads — so the NEXT read_screen starts blank,
+    regardless of what the app does. It does NOT touch the running app (it sends
+    nothing to the app's stdin) and can't un-freeze a hung process — kill that
+    instead. After a reset the screen repopulates as the app emits output, so
+    for a live app prefer `send_keys(id, ["C-l"])` first to force a redraw;
+    reach for reset_terminal when even that won't clear the corruption."""
+    client, int_id = _route(id)
+    return client.reset_terminal(int_id)
 
 
 @mcp.tool()

--- a/webterm/protocol.py
+++ b/webterm/protocol.py
@@ -183,6 +183,13 @@ def git_status_please_frame(req: int) -> str:
     return json.dumps({"type": "git_status_please", "req": int(req)})
 
 
+def reset_please_frame(req: int) -> str:
+    """Broker -> producer: clear the PTY-output ring so the next read_screen /
+    reconnect snapshot renders from a clean slate (#27). Only agents answer it
+    (a non-agent producer has no handler -> the RPC times out -> 502)."""
+    return json.dumps({"type": "reset_please", "req": int(req)})
+
+
 # Producer -> broker: the matching replies.
 def procs_frame(req: int, procs) -> str:
     return json.dumps({"type": "procs", "req": int(req),
@@ -196,6 +203,15 @@ def killed_frame(req: int, ok: bool, error: Optional[str] = None,
         frame["error"] = str(error)
     if pid is not None:
         frame["pid"] = int(pid)
+    return json.dumps(frame)
+
+
+def reset_done_frame(req: int, ok: bool, error: Optional[str] = None) -> str:
+    """Producer -> broker: ack for reset_please (#27)."""
+    frame: Dict[str, Any] = {"type": "reset_done", "req": int(req),
+                             "ok": bool(ok)}
+    if error:
+        frame["error"] = str(error)
     return json.dumps(frame)
 
 


### PR DESCRIPTION
Closes #27.

## What

A corrupted TUI screen has two distinct causes that the original issue conflated: **display ghosting** (app alive, only the rendered grid is wrong) vs **a hung app** (process stopped reading stdin). They need different recoveries, and — as #27 corrects — a reset sequence sent on **stdin** (`\033c` RIS / `\033[!p` DECSTR) does **not** clean Browserland''s render: those bytes reach the app as keystrokes, while the grid is rebuilt on every `read_screen` from the PTY **output** ring, never from injected input.

### Part 1 — discoverability (docs)
`send_input` / `send_keys` tool descriptions now steer to `send_keys([C-l])` to make a **live** app repaint (new stdout the renderer picks up), and warn that a raw reset on `send_input` won''t clear the rendered screen. Neither un-freezes a hung app — that''s a kill, out of scope here.

### Part 2 — `reset_terminal` MCP tool
New tool → `POST /mcp/reset` → broker RPC (`reset_please`/`reset_done`, **readwrite-gated**) → **agent**, which clears its `ByteRing` and wakes any wait-for-change waiters (#26). The next `read_screen` renders from a clean slate, regardless of what the app does. The **running app is untouched**.

Wire: `protocol.reset_please_frame`/`reset_done_frame`; client dispatch + `on_reset_request`; broker `_mcp_reset` + `/mcp/reset` route + preflight + registry routing of `reset_done`; `mcptool` client `reset_terminal`.

## Testing
- Protocol frame round-trips (request + ack, with/without error).
- Agent integration: ring cleared, `evicted` flag reset, `_output_gen` bumped (parked waiters woken), subsequent `read_screen` re-renders blank with a well-formed `content_hash`.
- mcptool client: `reset_terminal` POSTs `{id}` to `/mcp/reset`; tool registered.
- **Full suite green: 419 passed, 10 skipped.**
- E2E smoke on an isolated `:4446` broker (cmd terminal): echoed a marker → `read_screen` shows it → `reset_terminal` → `read_screen` blank → shell still responds to a new command (proves the app survives the reset).

## Affected files
`webterm/protocol.py`, `webterm/agent/agent.py`, `webterm/agent/client.py`, `webterm/broker/app.py`, `webterm/broker/registry.py`, `webterm/mcptool/client.py`, `webterm/mcptool/server.py`, plus tests.