### PR TITLE
fix(ui): load @codemirror/state via the transitive range, not a drifting pin (#36)

### DIFF
--- a/webterm/broker/index.html
+++ b/webterm/broker/index.html
@@ -7799,20 +7799,31 @@
         // several state instances whose facet identities don't match — which
         // silently breaks language/extension wiring.
         //
-        // esm.sh dedupes a shared dep by URL, but ONLY when every importer
-        // resolves it to the same build. view/language/autocomplete/commands
-        // import @codemirror/state via semver RANGES (^6.5.0, ^6.4.0, ...) that
-        // esm.sh resolves to the LATEST matching build — so CM_VER.state below
-        // MUST stay pinned to that same latest build. Pin it LOWER and the
-        // direct import loads a 2nd state instance, and CM throws "Unrecognized
-        // extension value ... multiple instances of @codemirror/state" -> the
-        // textarea fallback. Keep state (and view/language, imported both
-        // directly and transitively) bumped in lockstep with what the ranges
-        // resolve to. (xterm needs none of this — single self-contained package.)
+        // esm.sh dedupes a shared dep by its RESOLVED concrete-build URL, but
+        // ONLY when every importer lands on that same build. view/language/
+        // autocomplete/commands import @codemirror/state via semver RANGES
+        // (^6.5.0, ^6.4.0, ...) + the same ?target=es2022 the browser uses, and
+        // esm.sh resolves all of them to the LATEST matching build's es2022 URL
+        // (currently /@codemirror/state@6.7.0/es2022/state.mjs).
+        //
+        // So `state` below is imported via the SAME request the transitive
+        // importers make — `@codemirror/state@^6.5.0?target=es2022` (verbatim
+        // what view@6.36.2's build imports) — NOT a manually pinned version.
+        // Two things make this the durable form:
+        //   - the RANGE auto-tracks whatever esm.sh resolves the transitive
+        //     ranges to, so it can't drift behind them (a low exact pin loaded a
+        //     2nd state instance -> CM throws "Unrecognized extension value ...
+        //     multiple instances of @codemirror/state" -> textarea fallback, #36);
+        //   - the explicit ?target=es2022 pins the build target so the direct
+        //     import can't land on a different per-UA build than the transitive
+        //     ?target=es2022 imports (e.g. under a non-es2022 browser default).
+        // DO NOT replace this with a bare exact version — that reintroduces #36
+        // the next time upstream advances the range resolution. (xterm needs none
+        // of this — single self-contained package.)
         const CM_CDN = 'https://esm.sh/';
         const CM_VER = {
             view: '@codemirror/view@6.36.2',
-            state: '@codemirror/state@6.6.0',
+            state: '@codemirror/state@^6.5.0?target=es2022',
             language: '@codemirror/language@6.10.8',
             commands: '@codemirror/commands@6.8.0',
             search: '@codemirror/search@6.5.10',


### PR DESCRIPTION
Closes #36.

## Root cause
The in-browser text editor rendered as a plain `<textarea>` (the offline fallback) because CodeMirror failed to load **every** time. `CM_VER.state` was pinned to `@codemirror/state@6.6.0`, but `view@6.36.2` and the language/commands/autocomplete packs import `@codemirror/state` transitively via the range `^6.5.0?target=es2022`, which esm.sh resolves to **6.7.0**. Two distinct concrete `state` builds loaded → mismatched facet identities → CodeMirror throws *"Unrecognized extension value … multiple instances of @codemirror/state"* → the `loadCodeMirror()` `.catch` keeps the textarea.

## Fix (one value + its comment)
Import `state` via the **same request the transitive importers make** —
`@codemirror/state@^6.5.0?target=es2022` (verbatim what `view@6.36.2`'s build imports) — instead of a manually pinned version:

- the **range** auto-tracks whatever esm.sh resolves the transitive ranges to, so the direct import can't drift behind them again (a low exact pin was the bug);
- the explicit **`?target=es2022`** stops the direct import landing on a different per-UA build than the transitive `?target=es2022` imports (e.g. under a non-es2022 browser default).

Both resolve to the byte-identical concrete URL `/@codemirror/state@6.7.0/es2022/state.mjs` → a single deduped instance. The loader comment is updated to forbid reverting to a bare exact pin (which would reintroduce #36 on the next upstream bump).

Chosen over the issue's "bump the pin to 6.7.0" one-liner because that re-creates the exact manual-lockstep fragility that caused this (and a bare version omits `?target=`, leaving a per-UA build ambiguity). Adversarial review (codex) flagged both the missing-target and the re-drift, and converged on the range+target form.

## Testing (Playwright Firefox, isolated `:4446` broker)
- **Negative control:** the old `6.6.0` import reproduces the *exact* #36 error string ("multiple instances of @codemirror/state") — proves the test discriminates.
- **Dedup proof:** the new `^6.5.0?target=es2022` import shares `view`'s `state` instance — a `view.lineNumbers()` extension is accepted by the direct `EditorState.create` (the cross-instance path that threw before).
- **Page loader:** `loadCodeMirror()` resolves; `EditorState.create` with `history()` + `lineNumbers()` works.
- **Real editor UI:** `launchTextEditor()` mounts `.cm-editor` (editable `.cm-content`, visible) — not the textarea fallback; **console 0 errors / 0 warnings**.
- **Language packs + full view:** javascript/python/json/html/markdown extensions and a full `EditorView` (lineNumbers + js + history + autocomplete) all render with no "Unrecognized extension" error.
- **Full pytest suite green: 419 passed, 10 skipped.**

## Affected files
`webterm/broker/index.html` (CM_VER.state + loader comment).
