### PR TITLE
fix(ui): file tools browse the whole host + open at the active terminal's cwd (#35)

### DIFF
--- a/tests/test_broker_e2e.py
+++ b/tests/test_broker_e2e.py
@@ -696,13 +696,13 @@ def test_state_validation(broker_proc):
     assert status == 400 and payload["error"] == "bad_state"
 
 
-def test_file_upload_roundtrip(broker_proc):
+def test_file_upload_roundtrip(broker_proc, tmp_path):
     _, _, base = broker_proc
     auth = {"Authorization": f"Bearer {TOKEN}",
             "Content-Type": "application/json"}
     import base64 as _b64
     name = ".webterm_upload_test.bin"
-    target = REPO / name                       # editor_root defaults to cwd
+    target = REPO / name                       # default dir = broker cwd
     payload_bytes = bytes(range(256)) * 4       # non-UTF-8 binary
     b64 = _b64.b64encode(payload_bytes).decode("ascii")
     try:
@@ -737,13 +737,18 @@ def test_file_upload_roundtrip(broker_proc):
             headers=auth)
         assert status == 400 and resp["error"] == "bad_base64"
 
-        # Escape attempt -> contained.
+        # Host-wide (#35): an ABSOLUTE path outside the default dir is now
+        # ALLOWED (no editor_root containment) — it writes and echoes the
+        # absolute path back. (pytest's tmp_path is auto-cleaned.)
+        outside = (tmp_path / "uploaded_outside.bin").resolve()
         status, resp = _http(
             "POST", f"{base}/file/upload",
-            body=json.dumps({"path": "../escape.bin",
+            body=json.dumps({"path": str(outside),
                              "content_b64": b64}).encode(),
             headers=auth)
-        assert status == 400 and resp["error"] == "path_outside_root"
+        assert status == 200 and resp["ok"] is True, resp
+        assert outside.read_bytes() == payload_bytes
+        assert resp["path"] == str(outside), resp
     finally:
         try:
             target.unlink()
@@ -751,73 +756,67 @@ def test_file_upload_roundtrip(broker_proc):
             pass
 
 
-def test_agent_doc_outside_editor_root(broker_proc, tmp_path):
-    """#16: AGENTS.md/CLAUDE.md at a LIVE terminal's cwd read/write even outside
-    editor_root (the broker's cwd = REPO here); other files there, and those
-    docs at a NON-live cwd, stay sandboxed out."""
-    _, port, base = broker_proc
+def test_file_api_is_host_wide(broker_proc, tmp_path):
+    """#35: the file API browses the WHOLE host (same auth gate as /launch, which
+    already grants shell-level filesystem access). ANY absolute path reads/writes
+    — not just AGENTS.md/CLAUDE.md, and with NO live terminal required. cwd/parent
+    are absolute; only malformed paths (Windows NTFS ADS) are rejected."""
+    _, _, base = broker_proc
     auth = {"Authorization": f"Bearer {TOKEN}",
             "Content-Type": "application/json"}
 
-    cwd_dir = tmp_path / "termcwd"          # acts as a terminal's cwd
-    cwd_dir.mkdir()
-    (cwd_dir / "AGENTS.md").write_text("hello agents", encoding="utf-8")
-    (cwd_dir / "secret.txt").write_text("nope", encoding="utf-8")
-    other_dir = tmp_path / "elsewhere"      # a dir with no live terminal
-    other_dir.mkdir()
-    (other_dir / "AGENTS.md").write_text("not live", encoding="utf-8")
+    d = tmp_path / "anywhere"               # far outside the broker's default dir
+    d.mkdir()
+    (d / "AGENTS.md").write_text("hello agents", encoding="utf-8")
+    (d / "secret.txt").write_text("a secret", encoding="utf-8")
 
-    def _read(path):
-        return _http("POST", f"{base}/file/read",
-                     body=json.dumps({"path": path}).encode(), headers=auth)
+    def _post(path, body):
+        return _http("POST", f"{base}{path}",
+                     body=json.dumps(body).encode(), headers=auth)
 
-    async def scenario():
-        producer = await websockets.connect(
-            f"ws://127.0.0.1:{port}/browserland", max_size=None)
-        try:
-            await producer.send(json.dumps({
-                "type": "hello", "window_id": 556021, "pid": 7, "title": "doc",
-                "cols": 80, "rows": 24, "cwd": str(cwd_dir)}))
-            for _ in range(50):
-                _, sessions = _http("GET", f"{base}/sessions?token={TOKEN}")
-                if any(s["id"] == 556021 for s in sessions):
-                    break
-                await asyncio.sleep(0.1)
-            else:
-                raise AssertionError("producer did not register")
+    # An ORDINARY file far outside the default dir reads (was path_outside_root)
+    # and the echoed path is absolute.
+    st, r = _post("/file/read", {"path": str(d / "secret.txt")})
+    assert st == 200 and r["ok"] and r["content"] == "a secret", r
+    assert r["path"] == str((d / "secret.txt").resolve()), r
 
-            # AGENTS.md at the live cwd reads even though it is outside the root.
-            st, r = _read(str(cwd_dir / "AGENTS.md"))
-            assert st == 200 and r["ok"] and r["content"] == "hello agents", r
+    # AGENTS.md likewise — no carve-out, no live terminal needed.
+    st, r = _post("/file/read", {"path": str(d / "AGENTS.md")})
+    assert st == 200 and r["content"] == "hello agents", r
 
-            # ...and writes (the response echoes the absolute path back).
-            st, r = _http("POST", f"{base}/file/write",
-                          body=json.dumps({"path": str(cwd_dir / "AGENTS.md"),
-                                           "content": "edited"}).encode(),
-                          headers=auth)
-            assert st == 200 and r["ok"], r
-            assert (cwd_dir / "AGENTS.md").read_text(encoding="utf-8") == "edited"
+    # Write to an absolute path outside the default dir; echoes absolute path.
+    st, r = _post("/file/write", {"path": str(d / "new.txt"),
+                                  "content": "written"})
+    assert st == 200 and r["ok"], r
+    assert (d / "new.txt").read_text(encoding="utf-8") == "written"
+    assert r["path"] == str((d / "new.txt").resolve()), r
 
-            # CLAUDE.md at the live cwd: exception applies (NOT path_outside_root),
-            # the file just doesn't exist yet -> 404 not_found (opens empty).
-            st, r = _read(str(cwd_dir / "CLAUDE.md"))
-            assert st == 404 and r["error"] == "not_found", r
+    # /file/list at an absolute dir: absolute cwd + absolute parent + entries.
+    st, r = _post("/file/list", {"path": str(d)})
+    assert st == 200 and r["ok"], r
+    assert r["cwd"] == str(d.resolve()), r
+    assert r["parent"] == str(d.parent.resolve()), r
+    names = {e["name"] for e in r["entries"]}
+    assert {"AGENTS.md", "secret.txt", "new.txt"} <= names, names
 
-            # A non-agent file at the live cwd is still sandboxed out.
-            st, r = _read(str(cwd_dir / "secret.txt"))
-            assert st == 400 and r["error"] == "path_outside_root", r
+    # A missing dir -> not_found; a file path -> not_a_directory.
+    st, r = _post("/file/list", {"path": str(d / "nope")})
+    assert st == 404 and r["error"] == "not_found", r
+    st, r = _post("/file/list", {"path": str(d / "secret.txt")})
+    assert st == 400 and r["error"] == "not_a_directory", r
 
-            # AGENTS.md at a dir with no live terminal is rejected.
-            st, r = _read(str(other_dir / "AGENTS.md"))
-            assert st == 400 and r["error"] == "path_outside_root", r
+    # At a filesystem ANCHOR (drive root / POSIX '/') parent is null so Up is
+    # inert — the only non-trivial branch of the host-wide parent logic.
+    anchor = Path(str(d.resolve())).anchor if sys.platform == "win32" else "/"
+    st, r = _post("/file/list", {"path": anchor})
+    assert st == 200 and r["ok"], r
+    assert r["cwd"] == anchor, r
+    assert r["parent"] is None, r
 
-            # NTFS alternate-data-stream spelling is rejected outright.
-            st, r = _read(str(cwd_dir / "AGENTS.md") + "::$DATA")
-            assert st == 400 and r["error"] == "path_outside_root", r
-        finally:
-            await producer.close()
-
-    asyncio.run(scenario())
+    # Windows NTFS alternate-data-stream spelling is still rejected.
+    if sys.platform == "win32":
+        st, r = _post("/file/read", {"path": str(d / "AGENTS.md") + "::$DATA"})
+        assert st == 400 and r["error"] == "bad_path", r
 
 
 def test_file_upload_requires_token(broker_proc):

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -1,0 +1,89 @@
+"""Unit tests for the host-wide file-API path resolver (#35).
+
+``_resolve_host_path`` replaced the ``editor_root`` sandbox: the file tools now
+browse the whole host (gated by the same auth as ``/launch``, which already
+grants shell-level filesystem access). These cover the resolution rules and the
+half-absolute / ADS rejections an adversarial review (codex) flagged."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from webterm.broker.app import _resolve_host_path
+
+WIN = sys.platform == "win32"
+
+
+def test_empty_resolves_to_default(tmp_path):
+    assert _resolve_host_path("", tmp_path) == tmp_path.resolve()
+
+
+def test_relative_joins_default(tmp_path):
+    assert _resolve_host_path("sub/leaf", tmp_path) == \
+        (tmp_path / "sub" / "leaf").resolve()
+
+
+def test_absolute_outside_default_is_allowed(tmp_path):
+    # Host-wide: an absolute path OUTSIDE the default dir is NOT rejected (the
+    # whole point of #35 — no editor_root containment).
+    other = tmp_path.parent
+    assert _resolve_host_path(str(other), tmp_path) == other.resolve()
+
+
+def test_dotdot_escapes_default_dir(tmp_path):
+    # `..` is collapsed and escaping the start dir is allowed by design (#35),
+    # not a traversal bug to defend against.
+    sub = tmp_path / "a" / "b"
+    sub.mkdir(parents=True)
+    assert _resolve_host_path("../..", sub) == tmp_path.resolve()
+
+
+def test_resolver_errors_map_to_bad_path(tmp_path, monkeypatch):
+    # A resolver blow-up (symlink loop, bad drive) surfaces as ValueError so the
+    # endpoint returns a clean bad_path, never a 500.
+    import webterm.broker.app as app_mod
+
+    def boom(self, *a, **k):
+        raise OSError("symlink loop")
+
+    monkeypatch.setattr(app_mod.Path, "resolve", boom)
+    with pytest.raises(ValueError):
+        _resolve_host_path("anything", tmp_path)
+
+
+@pytest.mark.skipif(not WIN, reason="NTFS alternate-data-stream semantics")
+def test_windows_ads_rejected(tmp_path):
+    # Leaf, mid-component, and bare-relative ADS spellings all rejected...
+    for bad in (r"C:\dir\file:ads", r"C:\dir:ads\file", "file:ads"):
+        with pytest.raises(ValueError):
+            _resolve_host_path(bad, tmp_path)
+    # ...but the drive anchor's own colon must NOT false-reject a normal path.
+    assert _resolve_host_path(r"C:\dir\file", tmp_path) == \
+        Path(r"C:\dir\file").resolve()
+
+
+@pytest.mark.skipif(not WIN, reason="windows drive/root semantics")
+def test_windows_half_absolute_rejected(tmp_path):
+    # Drive-relative (C:foo) and rooted-relative (\foo) would jump to a drive
+    # root if joined onto default_dir — reject them outright.
+    for bad in ("C:foo", "\\foo"):
+        with pytest.raises(ValueError):
+            _resolve_host_path(bad, tmp_path)
+
+
+@pytest.mark.skipif(not WIN, reason="windows absolute semantics")
+def test_windows_absolute_kept(tmp_path):
+    assert _resolve_host_path(r"C:\Windows", tmp_path) == \
+        Path(r"C:\Windows").resolve()
+    # forward slashes (a browser may send them) normalise to the same path
+    assert _resolve_host_path("C:/Windows", tmp_path) == \
+        Path(r"C:\Windows").resolve()
+
+
+@pytest.mark.skipif(WIN, reason="POSIX absolute + legal-colon semantics")
+def test_posix_absolute_and_colon_filenames(tmp_path):
+    assert _resolve_host_path("/etc", tmp_path) == Path("/etc").resolve()
+    # ':' is a legal POSIX filename char — must NOT be rejected as ADS.
+    assert _resolve_host_path("weird:name", tmp_path) == \
+        (tmp_path / "weird:name").resolve()

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -18,8 +18,14 @@ broker reachable over the LAN/Tailscale unable to answer the UI's cross-origin
 /sessions fetch (the reported bug) even though any non-browser client could
 already read it; CORS only ever governs *browser* reads, and the real gate is
 network reachability plus the token on every mutation/data endpoint (/launch,
-/file/*, /state stay token-or-loopback gated, so a cross-origin page still
-cannot drive them). The header must ride on error responses too or a
+/file/*, /state are token-or-loopback gated). With a token configured a
+cross-origin page cannot drive them (it carries no token). With NO token the
+gate is loopback-only: a same-machine cross-origin page CAN reach them over
+loopback and, because ACAO is ``*``, read the response — the accepted
+single-user-loopback exposure (same as /launch). NOTE since #35 that exposure
+is host-wide for /file/* (full host read/write, the same trust /launch already
+grants by spawning shells), so a tokenless broker must not run while the same
+browser visits untrusted sites. The header must ride on error responses too or a
 cross-origin login probe surfaces as a fetch TypeError ("wrong password"
 indistinguishable from "host down"). Preflights are explicit OPTIONS routes
 (route resolution happens before request middleware, so middleware can't answer
@@ -174,101 +180,52 @@ def _write_state_atomic(path: Path, state: Dict[str, Any]) -> None:
                 pass
 
 
-def _resolve_in_root(root: Path, rel: str) -> Path:
-    """Resolve a client-supplied path under ``root``, rejecting any escape via
-    ``..`` or a symlink.
+def _resolve_host_path(rel: str, default_dir: Path) -> Path:
+    """Resolve a client-supplied file path **host-wide** — anywhere on this box,
+    with NO ``editor_root`` confinement (#35).
 
-    ``Path.resolve()`` (strict=False) collapses ``..`` and follows symlinks for
-    the segments that DO exist, so a not-yet-created leaf (Save As of a new
-    file) is still resolved against its real, symlink-followed parent — the
-    containment check therefore covers both existing and new paths. An absolute
-    client path bypasses the join but is still containment-checked, so it can
-    only ever resolve to something already inside ``root``."""
-    base = Path(rel or "")
-    p = (root / base) if not base.is_absolute() else base
-    p = p.resolve()
-    if p != root and root not in p.parents:
-        raise ValueError("path outside editor_root")
-    return p
+    The file API shares the EXACT auth gate as ``/launch`` (token when
+    configured, else loopback-only), and an authenticated client already has
+    full filesystem access through its terminal shells — so sandboxing the file
+    tools adds friction without adding security. Browsing is therefore host-wide,
+    gated only by that auth + per-host routing (the same single-user threat model
+    the AGENTS.md carve-out, #16, already accepted for two filenames; this just
+    generalises it to every file).
 
-
-# The editor sandbox (editor_root) is narrower than where terminals run: a
-# terminal's cwd can be anywhere (a parent of the root, another drive, …), so its
-# AGENTS.md/CLAUDE.md may sit outside the root. These two docs — and only these
-# two — are editable at a LIVE terminal's cwd even outside editor_root (#16).
-# Compared case-folded: a case-insensitive FS (Windows/macOS) resolves the real
-# on-disk casing, so an existing ``agents.md`` must still match.
-_AGENT_DOC_NAMES = frozenset({"agents.md", "claude.md"})
-
-
-def _agent_doc_at_live_cwd(rel: str, ctx) -> Optional[Path]:
-    """If ``rel`` is an absolute ``AGENTS.md``/``CLAUDE.md`` (any case) whose
-    parent dir is the cwd of a currently-registered terminal, return its
-    resolved path; else ``None``.
-
-    SECURITY MODEL (deliberate, per the issue-#16 decision): this is a *scoping*
-    heuristic, NOT a hard sandbox. It keeps the normal AGENTS-button flow and
-    honest clients within terminal working dirs, but the cwd is self-reported by
-    the producer, so it is not a boundary against a hostile authenticated client
-    (which could register a producer advertising any cwd). That is an accepted,
-    bounded widening of the editor for exactly two filenames: an authenticated
-    client already has full filesystem access through its terminal shells, so it
-    grants no new privilege. The real gates are the browser auth token and the
-    two-filename allowlist; a true boundary would need server-established
-    producer/cwd identity (out of scope here).
-
-    ``resolve()`` collapses ``..`` and follows symlinks, so the post-resolve
-    basename/parent are real — a symlink/traversal can't smuggle in another file.
-    A TOCTOU swap of a path component between this check and the open/write is
-    possible, but it is the same pre-existing race as the in-root ``/file``
-    endpoints and immaterial under this single-user threat model."""
-    base = Path(rel or "")
-    # Reject NTFS alternate-data-stream spellings (``AGENTS.md::$DATA``) outright
-    # rather than relying on resolve() folding them back to the base file.
-    if ":" in base.name:
-        return None
+    Resolution rules (cross-platform; deliberately strict about the half-absolute
+    Windows spellings pathlib would otherwise join surprisingly — codex review):
+      - empty ``rel`` -> ``default_dir`` (the initial dir, e.g. a terminal cwd).
+      - a fully-absolute path (POSIX ``/x``; Windows ``C:\\x`` or
+        ``\\\\srv\\share``) is taken as-is.
+      - a *drive-relative* (``C:foo``) or *rooted-relative* (``\\foo``) path —
+        ``drive`` or ``root`` set but not BOTH, i.e. not ``is_absolute()`` — is
+        rejected, because joining it onto ``default_dir`` would jump to a drive
+        root instead of staying under it.
+      - any other relative path joins onto ``default_dir``.
+    ``resolve()`` then collapses ``..`` and follows symlinks (escaping the start
+    dir is the POINT here, not a bypass to defend against). A colon in any
+    non-anchor component (``file:ads``, ``dir:x\\f``) is an NTFS
+    alternate-data-stream spelling and is rejected. Resolver failures (symlink
+    loop, bad drive) raise ``ValueError`` -> the caller maps to ``bad_path``."""
+    raw = rel or ""
+    base = Path(raw)
+    # ADS guard (Windows only — ':' is a legal filename char on POSIX): drop the
+    # drive/anchor (``C:`` / ``\\\\srv\\share``); any ':' left in the remainder is
+    # an NTFS alternate-data-stream marker, never a path separator.
+    if os.name == "nt" and ":" in raw[len(base.drive):]:
+        raise ValueError("bad_path")
+    if not raw:
+        p = default_dir
+    elif base.is_absolute():
+        p = base
+    elif base.drive or base.root:
+        raise ValueError("bad_path")        # half-absolute: C:foo / \foo
+    else:
+        p = default_dir / base
     try:
-        if not base.is_absolute():
-            return None
-        p = base.resolve()
-    except (OSError, ValueError):
-        return None
-    if p.name.lower() not in _AGENT_DOC_NAMES:
-        return None
-    parent = p.parent
-    for cwd in ctx.registry.live_cwds():
-        try:
-            if Path(cwd).resolve() == parent:
-                return p
-        except (OSError, ValueError):
-            continue
-    return None
-
-
-def _resolve_editor_path(root: Path, rel: str, ctx):
-    """Resolve a client file path for the editor API. Returns ``(path, in_root)``.
-
-    Normally the path is sandboxed to ``editor_root`` (``in_root=True``). As a
-    narrow exception, an ``AGENTS.md``/``CLAUDE.md`` at a live terminal's cwd is
-    allowed outside the root (``in_root=False``) — see :data:`_AGENT_DOC_NAMES`.
-    Raises ``ValueError`` when neither applies (caller maps to
-    ``path_outside_root``)."""
-    try:
-        return _resolve_in_root(root, rel), True
-    except ValueError:
-        pass
-    p = _agent_doc_at_live_cwd(rel, ctx)
-    if p is not None:
-        return p, False
-    raise ValueError("path outside editor_root")
-
-
-def _editor_resp_path(p: Path, root: Path, in_root: bool) -> str:
-    """The ``path`` echoed back to the client: root-relative for in-root files
-    (so the editor keeps using relative paths), absolute for the out-of-root
-    agent-doc exception (``relative_to(root)`` would raise, and the next save
-    must round-trip the same absolute path back through the exception)."""
-    return p.relative_to(root).as_posix() if in_root else str(p)
+        return p.resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError("bad_path") from exc
 
 
 def _json_object_body(request: "Request") -> Optional[Dict[str, Any]]:
@@ -344,13 +301,16 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         broker_port=port,
         token=app.ctx.auth_token,
     )
-    # Editor file-API sandbox root. Default = the broker's CWD (the box it runs
-    # on — this is a single-user loopback tool); set "editor_root" in the config
-    # to confine Open/Save elsewhere. Resolved once so every request compares
-    # against a stable, symlink-collapsed absolute path.
+    # Editor file-API DEFAULT directory (NOT a sandbox, #35). The file tools
+    # browse the whole host (same auth gate as /launch, which already grants
+    # shell-level filesystem access — see _resolve_host_path); this is only the
+    # dir an empty path resolves to, i.e. where Open/Save lands when no terminal
+    # cwd was supplied. Default = the broker's CWD (the box it runs on — a
+    # single-user loopback tool); override with "editor_root" in the config.
+    # Resolved once into a stable, symlink-collapsed absolute path.
     app.ctx.editor_root = Path(
         config.get("editor_root") or os.getcwd()).resolve()
-    LOGGER.info("editor file-API root: %s", app.ctx.editor_root)
+    LOGGER.info("editor file-API default dir: %s", app.ctx.editor_root)
     # Shared per-broker UI state (settings + layout) for /state. Persisted as
     # JSON beside the broker config (override with "state_path"); rev lives in
     # the file so a restart preserves optimistic-concurrency ordering. The lock
@@ -663,12 +623,11 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         body = _json_object_body(request)
         if body is None:
             return sanic_json({"ok": False, "error": "bad_json"}, status=400)
-        root = app.ctx.editor_root
         try:
-            d = _resolve_in_root(root, str(body.get("path") or ""))
+            d = _resolve_host_path(str(body.get("path") or ""),
+                                   app.ctx.editor_root)
         except ValueError:
-            return sanic_json({"ok": False, "error": "path_outside_root"},
-                              status=400)
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
         if not d.exists():
             return sanic_json({"ok": False, "error": "not_found"}, status=404)
         if not d.is_dir():
@@ -689,14 +648,14 @@ def create_app(config: Optional[Dict[str, Any]] = None,
             return sanic_json({"ok": False, "error": str(exc)}, status=400)
         # Dirs first, then case-insensitive by name.
         entries.sort(key=lambda e: (e["type"] != "dir", e["name"].lower()))
-        parent = None
-        if d != root:
-            parent = ("" if d.parent == root
-                      else d.parent.relative_to(root).as_posix())
+        # Host-wide (#35): cwd/parent are ABSOLUTE. parent is null only at a
+        # filesystem anchor (``/``, ``C:\`` or ``\\srv\share``), where
+        # ``d.parent == d`` — Up is inert there (no drive-list nav by design).
+        parent = None if d.parent == d else str(d.parent)
         return sanic_json({
             "ok": True,
-            "root": str(root),
-            "cwd": "" if d == root else d.relative_to(root).as_posix(),
+            "root": str(d.anchor),             # the FS anchor (informational)
+            "cwd": str(d),
             "parent": parent,
             "entries": entries,
         })
@@ -711,13 +670,11 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         rel = body.get("path")
         if not isinstance(rel, str) or not rel:
             return sanic_json({"ok": False, "error": "bad_path"}, status=400)
-        root = app.ctx.editor_root
         try:
-            p, in_root = _resolve_editor_path(root, rel, app.ctx)
+            p = _resolve_host_path(rel, app.ctx.editor_root)
         except ValueError:
-            return sanic_json({"ok": False, "error": "path_outside_root"},
-                              status=400)
-        if p == root or not p.exists():
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        if not p.exists():
             return sanic_json({"ok": False, "error": "not_found"}, status=404)
         if not p.is_file():
             return sanic_json({"ok": False, "error": "not_a_file"},
@@ -738,7 +695,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         except UnicodeDecodeError:
             return sanic_json({"ok": False, "error": "not_utf8"}, status=400)
         return sanic_json({"ok": True,
-                           "path": _editor_resp_path(p, root, in_root),
+                           "path": str(p),       # absolute, host-wide (#35)
                            "content": content})
 
     async def _file_write(request: Request):
@@ -758,13 +715,9 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         data = content.encode("utf-8")
         if len(data) > MAX_FILE_BYTES:
             return sanic_json({"ok": False, "error": "too_large"}, status=400)
-        root = app.ctx.editor_root
         try:
-            p, in_root = _resolve_editor_path(root, rel, app.ctx)
+            p = _resolve_host_path(rel, app.ctx.editor_root)
         except ValueError:
-            return sanic_json({"ok": False, "error": "path_outside_root"},
-                              status=400)
-        if p == root:
             return sanic_json({"ok": False, "error": "bad_path"}, status=400)
         if p.exists() and not p.is_file():
             return sanic_json({"ok": False, "error": "not_a_file"},
@@ -796,11 +749,11 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                 except OSError:
                     pass
         return sanic_json({"ok": True,
-                           "path": _editor_resp_path(p, root, in_root)})
+                           "path": str(p)})      # absolute, host-wide (#35)
 
     async def _file_upload(request: Request):
         # Binary-safe drop target (base64 content) — /file/write is UTF-8-text
-        # only. Same containment, atomic write, gate and cap as /file/write,
+        # only. Same host-wide resolution, atomic write, gate and cap as /file/write,
         # plus an `overwrite` flag (default false) so a drop never silently
         # clobbers an existing file (409 instead).
         err = _file_auth_error(request)
@@ -824,13 +777,9 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                               status=400)
         if len(data) > MAX_FILE_BYTES:
             return sanic_json({"ok": False, "error": "too_large"}, status=400)
-        root = app.ctx.editor_root
         try:
-            p = _resolve_in_root(root, rel)
+            p = _resolve_host_path(rel, app.ctx.editor_root)
         except ValueError:
-            return sanic_json({"ok": False, "error": "path_outside_root"},
-                              status=400)
-        if p == root:
             return sanic_json({"ok": False, "error": "bad_path"}, status=400)
         if p.exists():
             if not p.is_file():
@@ -860,7 +809,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                 except OSError:
                     pass
         return sanic_json({"ok": True,
-                           "path": p.relative_to(root).as_posix(),
+                           "path": str(p),       # absolute, host-wide (#35)
                            "size": len(data)})
 
     # ---- task manager + git button (/session/*) --------------------------

--- a/webterm/broker/index.html
+++ b/webterm/broker/index.html
@@ -2227,8 +2227,12 @@
                 // reopened remote-host editor still targets the right broker
                 // (a since-removed host falls back to local via fileHost()).
                 fileHostId: win.fileHostId || 'local',
-                // File-manager-only: the two panes' current root-relative dirs,
-                // so a reopened FM lands back where it was. Harmless empty
+                // Editor-only: the terminal cwd a blank editor was opened at, so
+                // its Open/Save dialogs keep opening "where I am" after a reload
+                // (#35 review — a saved editor uses filePath's dir instead).
+                startDir: win.startDir || '',
+                // File-manager-only: the two panes' current dirs (absolute since
+                // #35), so a reopened FM lands back where it was. Harmless empty
                 // strings for notes/editors (which never read them back).
                 fmLeft: win.fmLeft || '',
                 fmRight: win.fmRight || '',
@@ -6093,6 +6097,10 @@
         }
         let cascadeIndex = 0;
         let frontId = null;
+        // The most-recently-fronted TERMINAL window id (NOT an app window), so
+        // the file tools can open "where I am" — at the active terminal's cwd
+        // and on its host (#35). bringToFront keeps it current.
+        let lastTermId = null;
         let refreshInFlight = false;
         // Per-window MCP-pin re-assertions in flight (by window key). The 2s
         // re-assert pass never fires a duplicate POST for a key it is already
@@ -6886,6 +6894,9 @@
             // A floating window masked off the active workspace (task 8) can't
             // take focus — its taskbar click switches workspace first.
             if (!win.tiled && win.dom.classList.contains('ws-hidden')) return;
+            // Remember the active TERMINAL (not an app window) so the file tools
+            // can open "where I am" — at its cwd, on its host (#35).
+            if (win.type !== 'app') lastTermId = id;
             if (win.tiled) {
                 // Tiled windows live in normal flow (z-index is inert on a
                 // static box): "front" means make their column the focused one
@@ -7627,16 +7638,47 @@
                 () => ({ ok: false, error: 'HTTP ' + r.status })
             )).catch(e => ({ ok: false, error: String(e) }));
         }
+        // Host-wide file tools (#35) work in ABSOLUTE native paths: the server
+        // returns the host's own separators (C:\a\b on Windows, /a/b on POSIX).
+        // The file API only ever deals in ABSOLUTE paths, so a leading
+        // drive-letter (C:\) or UNC (\\srv) prefix unambiguously marks Windows —
+        // we must NOT sniff for any stray backslash, because '\' is a legal
+        // filename char on POSIX (a dir named `we\b` would otherwise corrupt
+        // joins + basenames; #35 review).
+        function pathSepOf(p) {
+            return /^([A-Za-z]:[\\/]|\\\\)/.test(p || '') ? '\\' : '/';
+        }
+        function joinNative(dir, name) {
+            if (!dir) return name;                 // empty -> server default dir
+            const sep = pathSepOf(dir);
+            return dir.charAt(dir.length - 1) === sep
+                ? dir + name : dir + sep + name;   // don't double a trailing sep
+        }
+        function baseName(p) {
+            if (!p) return '';
+            const i = p.lastIndexOf(pathSepOf(p));   // sep-aware (not both seps)
+            return i === -1 ? p : p.slice(i + 1);
+        }
+        // The cwd + host ID of the most-recently-active terminal, so the file
+        // tools open "where I am" (#35). `host` is a host ID (not an object) to
+        // match win.fileHostId. Empty -> broker default dir + local host.
+        function activeTerminalStart() {
+            const t = lastTermId && sessions.get(lastTermId);
+            if (t && t.cwd) {
+                return { cwd: String(t.cwd), host: t.hostId || homeHostId() };
+            }
+            return { cwd: '', host: homeHostId() };
+        }
         function fmtSize(n) {
             if (!(n > 0)) return '';
             if (n < 1024) return n + ' B';
             if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' K';
             return (n / (1024 * 1024)).toFixed(1) + ' M';
         }
-        // Reusable file-browser dialog over the server's editor_root. Resolves
-        // to a chosen root-relative (forward-slash) path, or null on cancel.
-        // mode:'open' selects an existing file; mode:'save' navigates dirs and
-        // types a filename. Reuses the static #file-overlay panel.
+        // Reusable host-wide file-browser dialog (#35). Resolves to a chosen
+        // ABSOLUTE path (the host's own separators), or null on cancel. mode:
+        // 'open' selects an existing file; 'save' navigates dirs and types a
+        // filename; 'dir' picks a folder. Reuses the static #file-overlay panel.
         // The overlay is a singleton, so a second open() while one is live
         // would orphan the first promise + its keydown listener — _fileDlgFinish
         // lets a new call cleanly cancel (resolve null) the previous one first.
@@ -7688,31 +7730,23 @@
                     if (mode === 'save') {
                         const name = (nameEl.value || '').trim();
                         if (!name) { showErr('enter a filename'); return; }
-                        finish(state.cwd ? (state.cwd + '/' + name) : name);
+                        // cwd is ABSOLUTE now (#35); join the typed name onto it.
+                        finish(state.cwd ? joinNative(state.cwd, name) : name);
                     } else if (mode === 'dir') {
-                        // Return the ABSOLUTE path of the folder currently shown:
-                        // editor_root joined with the relative cwd. /launch's
-                        // realpath+isdir accepts an absolute path, not the
-                        // root-relative cwd open/save modes return.
-                        if (!state.root) { showErr('folder not loaded'); return; }
-                        const root = state.root.replace(/[\\/]+$/, '');
-                        // Windows iff a drive (C:\) or UNC (\\srv) root — NOT
-                        // merely "contains a backslash" (a POSIX dir name may).
-                        const sep = (/^[A-Za-z]:[\\/]/.test(root)
-                                     || /^\\\\/.test(root)) ? '\\' : '/';
-                        const rel = (state.cwd || '').replace(/[\\/]+/g, sep);
-                        finish(rel ? (root + sep + rel) : root);
+                        // The shown folder's cwd IS the absolute path to return
+                        // (host-wide #35 — no root+relative reconstruction).
+                        if (!state.cwd) { showErr('folder not loaded'); return; }
+                        finish(state.cwd);
                     } else {
                         if (!state.selected) { showErr('select a file'); return; }
                         finish(state.selected);
                     }
                 };
                 const render = (data) => {
-                    state.cwd = data.cwd || '';
-                    state.root = data.root || '';
+                    state.cwd = data.cwd || '';        // absolute path (#35)
+                    state.root = data.root || '';      // FS anchor (informational)
                     state.selected = null;
-                    pathEl.textContent = data.root
-                        + (state.cwd ? ('  ›  ' + state.cwd) : '');
+                    pathEl.textContent = state.cwd || state.root || '';
                     listEl.innerHTML = '';
                     if (data.parent !== null && data.parent !== undefined) {
                         const up = document.createElement('div');
@@ -7733,8 +7767,7 @@
                             + (ent.type === 'dir' ? '' : fmtSize(ent.size))
                             + '</span>';
                         row.querySelector('.fe-name').textContent = ent.name;
-                        const child = state.cwd
-                            ? (state.cwd + '/' + ent.name) : ent.name;
+                        const child = joinNative(state.cwd, ent.name);
                         if (ent.type === 'dir') {
                             row.addEventListener('click', () => navigate(child));
                         } else if (mode === 'dir') {
@@ -8285,6 +8318,10 @@
                 // terminal's hostId so reads/writes hit the remote broker. A
                 // removed host falls back to local via fileHost() below.
                 fileHostId: appData.fileHostId || 'local',
+                // Initial dir for a NEW editor's Open/Save dialogs (#35): the
+                // active terminal's cwd, so a blank editor saves "where I am"
+                // instead of the broker's default dir. Ignored once filePath set.
+                startDir: appData.startDir ? String(appData.startDir) : '',
                 _saveTimer: null,
                 // CodeMirror handle (null until/unless CM mounts for an editor).
                 cmView: null,
@@ -8785,16 +8822,16 @@
                     }
                     return null;
                 };
+                // filePath is an ABSOLUTE host path now (#35), so split on EITHER
+                // separator (C:\a\b.txt as well as /a/b.txt). dirOf('') and a new
+                // editor's null filePath fall back to win.startDir (the terminal
+                // cwd the editor was opened at) so Open/Save start "where I am".
                 const dirOf = (p) => {
-                    if (!p) return '';
-                    const i = p.lastIndexOf('/');
-                    return i === -1 ? '' : p.slice(0, i);
+                    if (!p) return win.startDir || '';
+                    const i = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+                    return i === -1 ? (win.startDir || '') : p.slice(0, i);
                 };
-                const baseOf = (p) => {
-                    if (!p) return '';
-                    const i = p.lastIndexOf('/');
-                    return i === -1 ? p : p.slice(i + 1);
-                };
+                const baseOf = (p) => baseName(p);
                 // AGENTS.md guarantee: after a successful save of an AGENTS.md
                 // editor, ensure <cwd>/CLAUDE.md exists and references it with a
                 // bare `@AGENTS.md` line (Claude Code's include directive). Only
@@ -8836,7 +8873,8 @@
                         } else {
                             // Clean buffer: write through so buffer == disk.
                             const w = await fileApiPost('/file/write',
-                                { path: cwd + '/CLAUDE.md', content: next }, h);
+                                { path: joinNative(cwd, 'CLAUDE.md'),
+                                  content: next }, h);
                             if (w && w.ok) {
                                 // Only mark clean if the user didn't edit CLAUDE
                                 // during the write (overwrite-behind, Codex review).
@@ -8858,7 +8896,7 @@
                         }
                         return;
                     }
-                    const path = cwd + '/CLAUDE.md';
+                    const path = joinNative(cwd, 'CLAUDE.md');
                     const res = await fileApiPost('/file/read', { path }, h);
                     let text = '';
                     if (res && res.ok) text = res.content || '';
@@ -9672,7 +9710,7 @@
 
         // Midnight-Commander-style dual-pane file manager — a SEPARATE factory
         // from openAppWindow (which builds the delicate notes/editor body). It
-        // browses the broker's editor sandbox via /file/list, opens files into
+        // browses the host filesystem (#35) via /file/list, opens files into
         // the text editor (/file/read -> openAppWindow), and accepts file drops
         // (/file/upload). Same window shape + chrome + teardown contract as
         // openAppWindow so it tiles/drags/persists/reopens like any app window.
@@ -9798,7 +9836,14 @@
                     ? Object.assign({}, appData.floatGeom) : null,
                 locked,
                 dirty: false,
-                // The two panes' current root-relative dirs ('' = sandbox root).
+                // Which broker's filesystem this manager browses (#35): the host
+                // ID of the terminal it was opened from, else local. All /file/*
+                // calls below route through it (via hostById).
+                fileHostId: appData.fileHostId || 'local',
+                // The two panes' current ABSOLUTE dirs ('' = the broker's default
+                // dir on first render, then adopted as the server's absolute cwd).
+                // A legacy root-relative value still resolves under the default
+                // dir, so old windows upgrade themselves to absolute on first list.
                 fmLeft: appData.fmLeft != null ? String(appData.fmLeft) : '',
                 fmRight: appData.fmRight != null ? String(appData.fmRight) : '',
             };
@@ -9822,15 +9867,18 @@
                 left.pane.classList.toggle('active', s === 'left');
                 right.pane.classList.toggle('active', s === 'right');
             };
-            // Compose a child path relative to a pane's cwd (root stays bare,
-            // never '/name' — the API uses '' for root + relative paths).
-            const joinPath = (cwd, name) => (cwd ? cwd + '/' + name : name);
+            // Compose an ABSOLUTE child path under a pane's cwd, in the host's
+            // own separator (#35). Empty cwd -> bare name (server default dir).
+            const joinPath = (cwd, name) => joinNative(cwd, name);
+            // All /file/* calls route to the browsed host (#35), not always local.
+            const fmHost = () => hostById(win.fileHostId);
 
             const renderPane = async (side, _retried) => {
                 const ui = sideOf(side);
                 const seq = ++paneSeq[side];
                 const reqDir = win[dirKey(side)];
-                const res = await fileApiPost('/file/list', { path: reqDir });
+                const res = await fileApiPost('/file/list', { path: reqDir },
+                                              fmHost());
                 // Drop a stale render: the window closed, a newer render started,
                 // or the pane navigated elsewhere while we awaited.
                 if (win.disposed || seq !== paneSeq[side]
@@ -9857,8 +9905,9 @@
                     win[dirKey(side)] = cwd;
                     saveAppWindow(win);
                 }
-                ui.path.textContent = '/' + cwd;
-                ui.path.title = '/' + cwd;
+                // Absolute path now (#35) — show it as-is, not '/'-prefixed.
+                ui.path.textContent = cwd;
+                ui.path.title = cwd;
                 ui.list.innerHTML = '';
                 // Selecting a row (single-click) marks it for Open/Enter; only
                 // file rows carry a path. Tracked per render via the .sel class.
@@ -9868,19 +9917,20 @@
                     row.classList.add('sel');
                 };
                 const openFile = async (path) => {
-                    const r = await fileApiPost('/file/read', { path });
+                    const r = await fileApiPost('/file/read', { path }, fmHost());
                     if (!r || !r.ok) {
                         showNotice('open failed: ' + ((r && r.error) || '?'));
                         return;
                     }
-                    const base = path.indexOf('/') === -1
-                        ? path : path.slice(path.lastIndexOf('/') + 1);
+                    // Open the file on the SAME host the manager is browsing (#35),
+                    // and at the dir it lives in, so its Save lands back there.
                     openAppWindow({
                         id: newAppId('editor'),
                         appKind: 'text-editor',
                         filePath: r.path || path,
                         content: r.content || '',
-                        title: base,
+                        title: baseName(r.path || path),
+                        fileHostId: win.fileHostId,
                     });
                 };
                 // '..' row (not at root): navigates to the parent dir.
@@ -9945,7 +9995,7 @@
             // A tiny upload helper that reads the 409/exists status (fileApiPost
             // hides it) so a drop onto an existing file can prompt + overwrite.
             const uploadFile = (path, b64, overwrite) =>
-                fetch(hostHttpUrl(localHost(), '/file/upload'), {
+                fetch(hostHttpUrl(fmHost() || localHost(), '/file/upload'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ path, content_b64: b64,
@@ -10707,26 +10757,21 @@
         // openAppWindow (which passes stored geom/color/tiling to preserve them).
         //   opts: { id, cwd, fileHostId, geom?, color?, locked?, floatGeom?,
         //           activeTab? }
-        // The /file API is sandboxed to the broker's editor_root; an AGENTS.md
-        // path_outside_root aborts with a notice, not_found opens an empty
-        // buffer (saving creates it). CLAUDE.md errors fall back to an empty
-        // buffer (best-effort — the AGENTS save later ensures it references
-        // @AGENTS.md).
+        // The /file API is host-wide (#35), so an AGENTS.md at any cwd opens;
+        // not_found opens an empty buffer (saving creates it). CLAUDE.md errors
+        // fall back to an empty buffer (best-effort — the AGENTS save later
+        // ensures it references @AGENTS.md).
         async function openAgentDocsWindow(opts) {
             const cwd = String(opts.cwd || '');
             const fileHostId = opts.fileHostId || 'local';
             const host = hostById(fileHostId) || localHost();
-            const agentsPath = cwd + '/AGENTS.md';
-            const claudePath = cwd + '/CLAUDE.md';
+            const agentsPath = joinNative(cwd, 'AGENTS.md');
+            const claudePath = joinNative(cwd, 'CLAUDE.md');
             const [aRes, cRes] = await Promise.all([
                 fileApiPost('/file/read', { path: agentsPath }, host),
                 fileApiPost('/file/read', { path: claudePath }, host),
             ]);
-            // AGENTS.md governs whether the folder is in the sandbox at all.
-            if (aRes && aRes.error === 'path_outside_root') {
-                showNotice('AGENTS.md is outside the editor sandbox (' + cwd + ')');
-                return;
-            }
+            // A real read error (not just "doesn't exist yet") aborts.
             if (aRes && !aRes.ok && aRes.error !== 'not_found') {
                 showNotice('open AGENTS.md failed: ' + ((aRes && aRes.error) || '?'));
                 return;
@@ -12258,14 +12303,17 @@
             }));
             // Task 7: pick a starting folder, then launch this host's default
             // profile (per-host defaultProfile, else broker default) there.
-            // Folders browse under the broker's editor_root; cancel = no-op.
+            // Folder picker browses the whole host now (#35); cancel = no-op.
+            // Browse on the SAME (possibly remote) host we'll launch on, so the
+            // chosen absolute path exists there — not the local FS (#35 review).
             items.push({
                 label: 'Open in folder…',
                 enabled: true,
                 action: async () => {
                     try {
                         const dir = await openFileDialog({ mode: 'dir',
-                                                           startDir: '' });
+                                                           startDir: '',
+                                                           host: host });
                         if (dir) launchProfile(host, hostDefaultProfile(host),
                                                dir);
                     } catch (_) {}
@@ -12281,11 +12329,17 @@
                             appKind: 'sticky-note', content: '' });
         }
         function launchTextEditor() {
+            // Open the Open/Save dialogs at the active terminal's cwd+host (#35).
+            const s = activeTerminalStart();
             openAppWindow({ id: newAppId('editor'),
-                            appKind: 'text-editor', content: '' });
+                            appKind: 'text-editor', content: '',
+                            startDir: s.cwd, fileHostId: s.host });
         }
         function launchFileManager() {
-            openAppWindow({ id: newAppId('fm'), appKind: 'file-manager' });
+            // Both panes start at the active terminal's cwd, on its host (#35).
+            const s = activeTerminalStart();
+            openAppWindow({ id: newAppId('fm'), appKind: 'file-manager',
+                            fmLeft: s.cwd, fmRight: s.cwd, fileHostId: s.host });
         }
         function launchTaskManager() {
             openAppWindow({ id: newAppId('tm'), appKind: 'task-manager' });


### PR DESCRIPTION
Closes #35.

## Problem
Opening the **file manager** or **text editor** ignored the active terminal's working directory and always started at the broker's fixed `editor_root`, then **trapped** you there: no `..`/Up at the root, and anything outside it (a parent, a sibling, another drive, the terminal's real cwd) was rejected `path_outside_root`. The file tools should open where the terminal is and browse the whole host.

## Why removing the sandbox is safe
`editor_root` was never a security boundary against an authenticated client. The `/file/*` API uses the **exact same** auth gate as `/launch` (`_gated_auth_error`: token when configured, else loopback-only), and `/launch` already spawns shells → full filesystem access. Confining the file tools added friction without adding security — the same reasoning the #16 AGENTS.md carve-out already accepted for two filenames, now generalised to every file. Threat model unchanged: single-user, loopback-or-token, per-host. (Adversarial design + diff review via codex and a multi-agent pass.)

## Backend (`app.py`)
New `_resolve_host_path(rel, default_dir)` replaces the sandbox resolvers (`_resolve_in_root`, `_resolve_editor_path`, `_editor_resp_path`, `_agent_doc_at_live_cwd` — all removed):
- empty → `default_dir`; fully-absolute → as-is; **half-absolute Windows spellings** (drive-relative `C:foo`, rooted-relative `\foo`) → rejected (joining them would jump to a drive root); other relative → joined on `default_dir`.
- `resolve()` collapses `..`/symlinks (escaping the start dir is the point, not a bypass); resolver errors → `bad_path` (never a 500).
- NTFS **alternate-data-stream** colons rejected (Windows only — `:` is a legal POSIX filename char).

`/file/list,/read,/write,/upload` echo **absolute** paths; `/file/list` returns absolute `cwd` + absolute `parent` (`null` only at a filesystem anchor where `dir.parent == dir`, so Up is inert at `C:\` / `\\srv\share` / `/`). `editor_root` is kept **only** as the default dir for an empty path.

## Frontend (`index.html`)
The file tools work in **absolute native paths** now: helpers `pathSepOf`/`joinNative`/`baseName`; `lastTermId` tracks the active terminal so `activeTerminalStart()` feeds `launchTextEditor`/`launchFileManager` its cwd+host; the file-manager pane and the shared `openFileDialog` were converted from root-relative to absolute (breadcrumb, `..` via server `parent`, child joins, save/dir commit); all `/file` ops route through the window's host (`win.fileHostId` via `hostById`) so a remote terminal's tools hit the right broker. A legacy root-relative `fmLeft`/`fmRight` still resolves under the default dir, then the pane adopts the server's absolute cwd — graceful, no migration code.

## Tests
- **New `tests/test_file_api.py`** — unit tests for `_resolve_host_path`: absolute, relative-join, `..` escape, resolver-error→`bad_path`, Windows ADS + half-absolute rejection, POSIX absolute + legal-colon filename.
- **`tests/test_broker_e2e.py`** — `test_file_upload_roundtrip` now asserts an absolute write **outside** the default dir succeeds; the #16-carve-out test is replaced by **`test_file_api_is_host_wide`** (ordinary + AGENTS files read/write anywhere with no live terminal; absolute `cwd`/`parent` from `/file/list`; `not_found`/`not_a_directory`; Windows ADS rejected).
- **Full suite green: 427 passed, 11 skipped.**

## Manual verification (Playwright Firefox, isolated `:4446` broker)
A terminal launched at `C:\Users\Administrator\fmtest35` (outside `editor_root`):
- file manager + editor **open there**; breadcrumb shows the absolute path (not `/C:\…`);
- `..` walks `fmtest35 → Administrator → Users → C:\`, where Up correctly goes **inert** (drive root);
- read/write/create land on disk anywhere (verified on disk); the editor mounts CodeMirror on the opened file;
- **console clean (0 errors / 0 warnings).**

## Adversarial review (multi-agent, on the diff)
A 4-dimension review (security / backend-paths / frontend / tests) with per-finding verification surfaced 7 confirmed findings. **Fixed in this PR** (low-risk, directly improve #35):
- **docstring lie** — the module CORS comment claimed cross-origin pages "cannot drive" `/file/*`; corrected to state that a **tokenless** broker's `/file/*` *is* reachable cross-origin over loopback (ACAO:`*`) and is now host-wide, so a tokenless broker must not run while the same browser visits untrusted sites;
- **"Open in folder…"** browsed the *local* broker but launched on the *menu's* host → now passes `host` so browse + launch hit the same broker;
- **`pathSepOf`** treated any backslash as Windows, corrupting POSIX filenames containing `\` → now keys off a drive-letter/UNC prefix (verified: `/home/we\b/c` joins correctly, basename `we\b`);
- **editor `startDir`** wasn't persisted → added to `saveAppWindow` so a blank editor still opens "where I am" after a reload;
- **test gap** — added an HTTP assertion that `/file/list` at a filesystem anchor returns `parent: null`.

**Deferred follow-ups** (pre-existing or posture, deliberately out of this PR's scope):
- *(med)* `/file/*` does **blocking FS I/O on the event loop** — a dead/slow UNC path can stall the whole broker; this predates #35 but host-wide widens the reachable targets. Proper fix is a thread-executor offload (the file already does this for state writes via `run_in_executor`). Worth a focused follow-up.
- *(low)* no **directory-listing cap** (a million-entry dir lists unbounded on the loop).
- *(posture)* the tokenless cross-origin `/file/*` surface is now host-wide; consider **requiring the token for `/file/*`** or **dropping the PNA preflight echo** — a deployment/security-model decision (affects all routes + tailscale/multi-host), so left for the maintainer.

## Affected files
`webterm/broker/app.py`, `webterm/broker/index.html`, `tests/test_file_api.py`, `tests/test_broker_e2e.py`.
