### PR TITLE
feat(ui): flash the robot MCP icon on read/write — distinct color/motion (#33)

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -96,6 +96,15 @@ def test_broker_to_producer_frames():
         "type": "snapshot_please"}
 
 
+def test_mcp_activity_frame():
+    # #33: a transient per-window MCP-touch pulse; carries only the kind (the
+    # window id is implicit in the per-session browser WS).
+    assert json.loads(protocol.mcp_activity_frame("read")) == {
+        "type": "mcp_activity", "kind": "read"}
+    assert json.loads(protocol.mcp_activity_frame("write")) == {
+        "type": "mcp_activity", "kind": "write"}
+
+
 def test_error_frame():
     assert json.loads(protocol.error_frame("unknown_session", 7)) == {
         "type": "error", "reason": "unknown_session", "session_id": 7}

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -323,6 +323,9 @@ def create_app(config: Optional[Dict[str, Any]] = None,
     app.ctx.state_lock = asyncio.Lock()
     LOGGER.info("UI state store: %s (rev %s)",
                 app.ctx.state_path, app.ctx.state["rev"])
+    # Detached fire-and-forget tasks (e.g. the #33 MCP-activity pulse), held in
+    # a set so they aren't GC'd mid-flight; each self-removes on completion.
+    app.ctx.bg_tasks = set()
     # Single-active-browser lease (in-memory liveness, NOT persisted): the one
     # clientId allowed to drive this broker, the set of live /control sockets
     # per clientId, and the lock serializing every claim/release. Resets to
@@ -1017,6 +1020,17 @@ def create_app(config: Optional[Dict[str, Any]] = None,
             out.append(entry_out)
         return sanic_json(out)
 
+    def _flash_mcp_activity(entry, kind: str) -> None:
+        # #33: emit a per-window MCP-activity pulse (browser flashes the robot
+        # icon — cool/soft for a read, warm/sharp for a write). Scheduled as a
+        # DETACHED task (not awaited) so the agent's read/write response latency
+        # never couples to a slow/backpressured browser WS send; broadcast_text
+        # swallows per-subscriber errors and no-ops with no subscribers.
+        task = asyncio.ensure_future(
+            entry.broadcast_text(protocol.mcp_activity_frame(kind)))
+        app.ctx.bg_tasks.add(task)
+        task.add_done_callback(app.ctx.bg_tasks.discard)
+
     async def _mcp_read(request: Request):
         err = _mcp_auth_error(request)
         if err is not None:
@@ -1024,6 +1038,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         entry, _mode, resp = _mcp_entry(request)
         if resp is not None:
             return resp
+        _flash_mcp_activity(entry, "read")    # #33 (detached; see helper)
         # Same correlated round-trip as /session/procs. A non-agent
         # (terminal) producer has no screen handler -> the RPC times out ->
         # 502 no_producer_rpc. busy/gone collapse to the same: there is no
@@ -1095,6 +1110,10 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         # authorized channel (gated by the MCP token + readwrite mode), not a
         # browser, so the one-active-browser rule does not apply to it.
         await entry.send_to_producer(protocol.input_frame(data))
+        # #33: pulse the robot icon on the write (warm/sharp flash) — only after
+        # a validated readwrite send, so a rejected/read-only attempt doesn't
+        # flash. Detached task (see _flash_mcp_activity).
+        _flash_mcp_activity(entry, "write")
         return sanic_json({"ok": True})
 
     async def _mcp_reset(request: Request):

--- a/webterm/broker/index.html
+++ b/webterm/broker/index.html
@@ -312,6 +312,30 @@
            off, so a window's MCP exposure is visible at a glance. */
         .term-window .mcp-btn svg { width: 13px; height: 13px; display: block; }
         .term-window .mcp-btn.mcp-off { opacity: 0.5; }
+        /* #33: transient MCP-activity pulse on the robot icon. Read = cool, soft,
+           slow glow (passive observation); write = warm, sharp, fast brightness
+           hit (active mutation) — unmistakable at a glance. Both animate only
+           box-shadow / filter so they ride on top of the .on (lit) and .mcp-off
+           (dimmed) states instead of fighting their background/opacity. */
+        @keyframes mcpReadPulse {
+            /* outer glow + an INSET half: the title bar's overflow:hidden clips
+               the top of an outward-only glow (the button has ~4px clearance),
+               so the inset keeps the read cue robust by painting in-bounds. */
+            0%   { box-shadow: 0 0 0 0 rgba(74,163,255,0), inset 0 0 0 0 rgba(74,163,255,0); }
+            40%  { box-shadow: 0 0 7px 2px rgba(74,163,255,0.80), inset 0 0 4px rgba(74,163,255,0.60); }
+            100% { box-shadow: 0 0 0 0 rgba(74,163,255,0), inset 0 0 0 0 rgba(74,163,255,0); }
+        }
+        @keyframes mcpWriteFlash {
+            0%   { box-shadow: 0 0 0 0 rgba(224,155,58,0); filter: brightness(1); }
+            18%  { box-shadow: 0 0 9px 3px rgba(224,155,58,0.95); filter: brightness(1.6); }
+            100% { box-shadow: 0 0 0 0 rgba(224,155,58,0); filter: brightness(1); }
+        }
+        .term-window .mcp-btn.mcp-flash-read  { animation: mcpReadPulse 280ms ease-in-out; }
+        .term-window .mcp-btn.mcp-flash-write { animation: mcpWriteFlash 200ms ease-out; }
+        @media (prefers-reduced-motion: reduce) {
+            .term-window .mcp-btn.mcp-flash-read,
+            .term-window .mcp-btn.mcp-flash-write { animation: none; }
+        }
         .term-window .mcp-popover {
             position: absolute;
             z-index: 50;
@@ -6801,6 +6825,7 @@
                 btn.title = 'MCP access: ' + lab;
             };
             win.refreshMcpBtn = refresh;   // kept live by refreshTaskbarInner
+            win.mcpBtn = btn;              // #33: target for the activity flash
 
             let pop = null;
             const closePop = () => {
@@ -6861,9 +6886,31 @@
                 btn.removeEventListener('click', onClick);
                 closePop();
                 win.refreshMcpBtn = null;
+                win.mcpBtn = null;
+                if (win._mcpFlashTimer) { clearTimeout(win._mcpFlashTimer);
+                    win._mcpFlashTimer = null; }
             });
             refresh();
             return btn;
+        }
+        // #33: briefly flash a window's robot icon on an MCP touch — cool/soft
+        // for a read, warm/sharp for a write, so observation vs mutation is
+        // tellable at a glance. No-op for windows without a robot button
+        // (app/non-terminal, or a pre-MCP broker where it's hidden). Re-triggers
+        // cleanly on a rapid burst by dropping the class + forcing a reflow.
+        function flashMcpBtn(win, kind) {
+            const btn = win && win.mcpBtn;
+            if (!btn) return;
+            const cls = kind === 'write' ? 'mcp-flash-write' : 'mcp-flash-read';
+            btn.classList.remove('mcp-flash-read', 'mcp-flash-write');
+            void btn.offsetWidth;                 // reflow -> restart keyframes
+            btn.classList.add(cls);
+            if (win._mcpFlashTimer) clearTimeout(win._mcpFlashTimer);
+            win._mcpFlashTimer = setTimeout(() => {
+                win._mcpFlashTimer = null;
+                if (win.mcpBtn) win.mcpBtn.classList.remove(
+                    'mcp-flash-read', 'mcp-flash-write');
+            }, 320);                              // > the longest keyframe (~300ms)
         }
 
         // ---- notices ------------------------------------------------------
@@ -10977,6 +11024,12 @@
                 }
                 if (data.type === 'output') {
                     try { win.term.write(data.data); } catch (_) {}
+                    return;
+                }
+                if (data.type === 'mcp_activity') {
+                    // #33: an agent just read (kind:'read') or wrote (kind:'write')
+                    // this window over MCP — pulse its robot icon.
+                    flashMcpBtn(win, data.kind === 'write' ? 'write' : 'read');
                     return;
                 }
                 if (data.type === 'title') {

--- a/webterm/protocol.py
+++ b/webterm/protocol.py
@@ -271,6 +271,16 @@ def error_frame(reason: str, session_id: int) -> str:
     })
 
 
+def mcp_activity_frame(kind: str) -> str:
+    """Transient per-window MCP-touch pulse (#33): the broker emits this on an
+    MCP read/write so the browser can briefly flash that window's robot icon
+    (cool/soft for a read, warm/sharp for a write). ``kind`` is ``"read"`` or
+    ``"write"``. The window id is intentionally omitted — every browser WS is
+    bound to one window via ``?session=<id>``, so a broadcast on that entry
+    already targets exactly the right window. Fire-and-forget; no reply."""
+    return json.dumps({"type": "mcp_activity", "kind": str(kind)})
+
+
 # ---------------------------------------------------------------------------
 # Control channel (/control) — single-active-browser lease
 #


### PR DESCRIPTION
Closes #33.

## What
Briefly flash a window's title-bar **robot MCP icon** whenever an MCP read or write touches that window, with a **distinct color/motion** for each, so you can see at a glance — in real time — that an agent is *reading* the screen vs *typing* into the terminal, without opening logs. The static lit state (`.on`) only says the window is *eligible* for MCP; this shows *activity*.

## Backend
- `protocol.mcp_activity_frame(kind)` → `{"type":"mcp_activity","kind":"read"|"write"}`. The window id is **omitted** — every browser WS is bound to one window via `?session=<id>`, so a broadcast on that `entry` already targets the right window (multi-host #24 safe).
- `_mcp_read` broadcasts `"read"` **after the entry resolves** (so a read that later 502s still flashes — the agent did touch it). `_mcp_input` broadcasts `"write"` **only after a validated readwrite `send_to_producer`** (a read-only / `bad_data` / `too_large` attempt never flashes). Fire-and-forget over the same `broadcast_text` path the title push already uses; it no-ops with no subscribers, and an `off` window is rejected by `_mcp_entry` before any broadcast.

## Frontend
- `attachMcpButton` exposes `win.mcpBtn` (nulled + flash timer cleared on teardown). A new `ws.onmessage` case routes `mcp_activity` to `flashMcpBtn(win, kind)`.
- `flashMcpBtn` re-triggers cleanly on a burst (drop both classes → force reflow → add the one) and clears after 320ms so it can re-fire; a safe no-op when the window has no robot button (app/non-terminal, or a pre-MCP broker where it's hidden).
- Two `@keyframes`: **`mcpReadPulse`** — cool `#4aa3ff` box-shadow glow, 280ms ease-in-out (passive observation); **`mcpWriteFlash`** — warm `#e09b3a` box-shadow + `filter: brightness()` hit, 200ms ease-out (active mutation). Both animate only `box-shadow`/`filter`, so they ride on top of `.on` (lit) and `.mcp-off` (dimmed) instead of fighting their background/opacity, on light and `.dark-accent` title bars alike. A `prefers-reduced-motion` guard disables them.

## Open questions from the issue, resolved
- **Debounce/spam:** handled on the frontend (re-trigger + 320ms auto-clear) rather than backend rate-limiting — a burst just keeps pulsing; verified 3/3 rapid reads re-fire.
- **Multi-host (#24):** id-less frame is correct — routing is per-WS/`?session=`.
- **`off` windows:** never flash (`_mcp_entry` rejects them before the broadcast).
- **Hidden / non-terminal windows:** `flashMcpBtn` no-ops when `win.mcpBtn` is absent.
- **Theme:** flash colors animate `box-shadow`/`filter` so they coexist with the existing `.on`/`.mcp-off`/`.dark-accent` rules across themes.

## Tests
- Protocol unit test for `mcp_activity_frame` (read + write shapes).
- **Full suite green: 428 passed, 11 skipped.**
- **Playwright** on a real MCP-enabled `:4446` broker: `/mcp/read` → `mcpReadPulse`, `/mcp/input` → `mcpWriteFlash`, the two **distinct** (neither bleeds into the other), class **auto-clears**, **3× rapid burst re-fires** each time, app-window **no-op**, **console clean**.

## Adversarial review (multi-agent) — 2 confirmed findings, both fixed
- *(low)* the pulse was `await`ed inline, coupling the agent's read/write response latency to a slow browser WS send (and the "fire-and-forget" comment was false) → now scheduled as a **detached task** (`asyncio.ensure_future` + a `bg_tasks` set so it isn't GC'd), so the response never blocks on a subscriber send.
- *(nit)* the read glow (pure outward `box-shadow`) was partially clipped by the title bar's `overflow:hidden`, while the write flash (`filter:brightness`) wasn't → added an **inset half-glow** to the read keyframe so the cue paints in-bounds and survives the clip.

(One finding dismissed on verification: "write flash fires even if the producer send silently failed" — by design, matching the endpoint's own `{"ok":true}` for a gone producer.)

## Affected files
`webterm/protocol.py`, `webterm/broker/app.py`, `webterm/broker/index.html`, `tests/test_protocol.py`.
