### PR TITLE
feat(ui): in-app searchable Help page + taskbar ? button (#40)

### DIFF
--- a/webterm/broker/index.html
+++ b/webterm/broker/index.html
@@ -789,6 +789,113 @@
         }
         #clock-chip.on { display: inline-flex; align-items: center; }
 
+        /* ---- #40 in-app Help: taskbar "?" chip + searchable overlay ----
+           The chip mirrors #clock-chip (hidden by default, shown via .on);
+           the overlay/modal are self-contained (they don't lean on the
+           #settings-modal id rules) but reuse the shared .set-* classes. */
+        #help-chip {
+            display: none;
+            flex: 0 0 auto;
+            font-family: monospace;
+            font-size: 12px;
+            font-weight: bold;
+            min-width: 20px;
+            height: 20px;
+            padding: 0 6px;
+            border-radius: 3px;
+            border: 1px solid var(--bg-3);
+            background: var(--bg);
+            color: var(--fg-dim);
+            user-select: none;
+            cursor: pointer;
+            margin-left: 2px;
+        }
+        #help-chip.on { display: inline-flex; align-items: center; justify-content: center; }
+        #help-chip:hover { color: var(--fg); border-color: var(--accent-default); }
+        #help-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.55);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 150001;   /* just above #settings-overlay (defense; openHelp also closes it) */
+        }
+        #help-overlay.open { display: flex; }
+        #help-modal {
+            background: var(--bg-2);
+            border: 1px solid #000;
+            border-left: 4px solid var(--accent-default);
+            border-radius: 4px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.7);
+            color: var(--fg);
+            font-family: Arial, sans-serif;
+            font-size: 13px;
+            padding: 14px 16px;
+            width: 560px;
+            max-width: 92vw;
+            max-height: 84vh;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        #help-search {
+            background: var(--bg);
+            border: 1px solid var(--bg-3);
+            border-radius: 3px;
+            color: var(--fg);
+            font-family: monospace;
+            font-size: 13px;
+            padding: 6px 9px;
+            outline: none;
+            width: 100%;
+            box-sizing: border-box;
+        }
+        #help-search:focus { border-color: var(--accent-default); }
+        #help-results {
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            padding-right: 4px;
+        }
+        .help-section { display: flex; flex-direction: column; gap: 7px; }
+        .help-section-title {
+            color: var(--fg-dim);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border-bottom: 1px solid var(--bg-3);
+            padding-bottom: 3px;
+        }
+        .help-entry { display: flex; flex-direction: column; gap: 2px; }
+        .help-entry .h-title { font-weight: bold; font-size: 12px; }
+        .help-entry .h-body { font-size: 12px; line-height: 1.45; }
+        .help-entry .h-keys {
+            align-self: flex-start;
+            font-family: monospace;
+            font-size: 11px;
+            color: var(--fg-dim);
+            background: var(--bg);
+            border: 1px solid var(--bg-3);
+            border-radius: 3px;
+            padding: 1px 5px;
+            margin-top: 1px;
+        }
+        #help-empty { color: var(--fg-dim); font-style: italic; font-size: 12px; }
+        #help-modal .set-foot { display: flex; justify-content: flex-end; }
+        #help-modal button {
+            background: var(--bg);
+            border: 1px solid var(--bg-3);
+            border-radius: 3px;
+            color: var(--fg);
+            font-family: monospace;
+            font-size: 12px;
+            padding: 5px 10px;
+            cursor: pointer;
+        }
+        #help-modal button:hover { background: #262626; border-color: #6a8; }
+
         /* edge / corner resize handles */
         .term-window .rh { position: absolute; z-index: 5; }
         .term-window .rh-n  { top: 0; left: var(--corner-size); right: var(--corner-size); height: var(--handle-thick); cursor: ns-resize; }
@@ -1442,6 +1549,8 @@
         <div id="host-status"></div>
         <button type="button" id="btn-fullscreen" title="Fullscreen" aria-label="Fullscreen">⛶</button>
         <div id="clock-chip" title="date &amp; time"></div>
+        <div id="help-chip" title="Help &#8212; interface guide" role="button"
+             tabindex="0" aria-label="Help">?</div>
     </div>
     <div id="notice-host"></div>
     <div id="drop-vbar"></div>
@@ -1506,6 +1615,14 @@
                     <div class="set-title">Date &amp; time</div>
                     <label class="set-check"><input type="checkbox" id="set-clock" />
                         Show date &amp; time (bottom-right)</label>
+                </div>
+                <div class="set-section set-browser-global">
+                    <div class="set-title">Help button</div>
+                    <label class="set-check"><input type="checkbox" id="set-help-button" />
+                        Show help (?) button (bottom-right)</label>
+                    <div class="set-hint">a searchable guide to every interface
+                        feature; opens from the &ldquo;?&rdquo; chip on the taskbar.
+                        You can also bind a key to it under Keyboard shortcuts.</div>
                 </div>
                 <div class="set-section set-browser-global">
                     <div class="set-title">Start button</div>
@@ -1654,6 +1771,18 @@
             </div>
             <div class="set-foot">
                 <button type="button" id="settings-close">close</button>
+            </div>
+        </div>
+    </div>
+    <div id="help-overlay">
+        <div id="help-modal">
+            <div class="set-head">Help &#8212; interface guide</div>
+            <input type="text" id="help-search" autocomplete="off" spellcheck="false"
+                   placeholder="Search&#8230;  (e.g. snap, tab, split, workspace, MCP, pin)" />
+            <div id="help-results"></div>
+            <div id="help-empty" style="display:none">No matches.</div>
+            <div class="set-foot">
+                <button type="button" id="help-close">close</button>
             </div>
         </div>
     </div>
@@ -2497,6 +2626,11 @@
                 s.termFont = '';
             }
             if (typeof s.clock !== 'boolean') s.clock = false;
+            // #40: the taskbar "?" help chip (browser-global, default ON) plus a
+            // one-time first-run nudge flag (flipped true once the hint shows or
+            // Help is first opened, so it never repeats).
+            if (typeof s.showHelpButton !== 'boolean') s.showHelpButton = true;
+            if (typeof s.helpHintSeen !== 'boolean') s.helpHintSeen = false;
             // Task 8: per-host default terminal profile. '' = use the broker's
             // own server default (the prior behavior).
             if (typeof s.defaultProfile !== 'string') s.defaultProfile = '';
@@ -6549,6 +6683,17 @@
             } catch (_) {}
         }
 
+        // ---- #40 help chip visibility --------------------------------------
+        // The taskbar "?" chip; same show/hide-on-an-`.on`-class pattern as the
+        // clock, driven by getSettings().showHelpButton. Reads only — converges
+        // on boot and on every /state pull via applyThemeSettings.
+        function applyHelpButton(on) {
+            try {
+                const el = document.getElementById('help-chip');
+                if (el) el.classList.toggle('on', !!on);
+            } catch (_) {}
+        }
+
         // ---- start button label --------------------------------------------
         // The `+` launch button doubles as the Win-style Start button. Only the
         // visible label changes; its click/contextmenu behavior is untouched.
@@ -6572,6 +6717,7 @@
                 applyTheme(s.theme);
                 applyPattern(s.pattern);    // after theme: reads the live vars
                 applyClock(s.clock);
+                applyHelpButton(s.showHelpButton);   // #40
                 applyStartButton();
                 applyTerminalFont();        // #18: configurable terminal font
             } catch (_) {}
@@ -13068,6 +13214,11 @@
               run: () => { if (settingsOverlay.classList.contains('open'))
                                closeSettings();
                            else openSettings(); } },
+            // #40: unbound by default (absent from DEFAULT_KEYBINDINGS) — shows in
+            // the keybindings editor as 'unset' so users can assign their own combo.
+            { id: 'toggle-help',     label: 'Toggle help',
+              run: () => { if (helpOverlay.classList.contains('open')) closeHelp();
+                           else openHelp(); } },
         ];
         const KEY_ACTION_BY_ID = {};
         for (const act of KEY_ACTIONS) KEY_ACTION_BY_ID[act.id] = act;
@@ -13555,6 +13706,7 @@
             if (e.key === 'Escape') {
                 hideCtxMenu();
                 closeSettings();
+                closeHelp();        // #40
             }
         });
         window.addEventListener('blur', hideCtxMenu);
@@ -13601,6 +13753,7 @@
         const setThemeEl = document.getElementById('set-theme');
         const setPatternEl = document.getElementById('set-pattern');
         const setClockEl = document.getElementById('set-clock');
+        const setHelpButtonEl = document.getElementById('set-help-button');   // #40
         const setStartLabelEl = document.getElementById('set-start-label');
         const setStartPathEl = document.getElementById('set-start-path');
         const setTermFontEl = document.getElementById('set-term-font');   // #18
@@ -13693,6 +13846,243 @@
         });
         document.getElementById('settings-close')
             .addEventListener('click', closeSettings);
+
+        // ---- #40 in-app Help: searchable interface guide --------------------
+        // A small modal that documents every interface feature. The corpus is
+        // mostly static prose; a few entries are GENERATED from live state
+        // (keybindings, launch profiles, MCP status) so they never go stale.
+        // Search is a case-insensitive substring over title+body+section+keys.
+        const helpOverlay = document.getElementById('help-overlay');
+        const helpSearchEl = document.getElementById('help-search');
+        const helpResultsEl = document.getElementById('help-results');
+        const helpEmptyEl = document.getElementById('help-empty');
+        // The corpus is rebuilt once per open (and once more when a cold
+        // generated source warms), NOT per keystroke — live state can't change
+        // between keystrokes within one open, so filtering reuses this snapshot.
+        let _helpCorpus = [];
+        const HELP_ENTRIES_STATIC = [
+            { section: 'Getting started', title: 'Open this guide',
+              body: 'Click the "?" chip at the bottom-right of the taskbar, or bind a key to it under Control Panel -> Keyboard shortcuts (the "Toggle help" action). Type in the box above to filter every entry live.' },
+            { section: 'Getting started', title: 'Control Panel',
+              body: 'The gear opens the Control Panel: appearance, window mode, drag hold delay, hosts, MCP, and keyboard shortcuts. Appearance is per-browser; most other settings are per-host (a tab per broker).' },
+            { section: 'Layout modes', title: 'Floating vs. tiling',
+              body: 'Two window modes. Floating = free-moving, overlapping windows you place anywhere. Tiling = a niri-style horizontal strip of non-overlapping columns. Switch in Control Panel -> Window mode, or with the "Toggle tiling mode" shortcut.' },
+            { section: 'Layout modes', title: 'The tiling strip',
+              body: 'In tiling mode, windows live in columns along a strip that scrolls left/right. Scroll with the workspace scrollbar, by dragging near the strip edge, or with the focus/move-column shortcuts.' },
+            { section: 'Snapping & pop-out', title: 'Snap a floating window into the grid (hold-to-snap)',
+              body: 'While dragging a FLOATING window, hold it still for the dwell (default ~3s) to enter snap mode; drop zones light up; release to tile it. The top-left "return to floating" zone, or Escape, cancels.' },
+            { section: 'Snapping & pop-out', title: 'Pop a tiled window out to a float',
+              body: 'While dragging a TILED window, hold it still for the dwell to arm a "release to float" mode (a dashed outline + the bottom band appear); release to detach it as a floating window. Move on again to cancel and keep tiling; Escape aborts the drag.' },
+            { section: 'Snapping & pop-out', title: 'Hold delay (configurable)',
+              body: 'The hold time for both gestures is set per host in Control Panel -> Drag hold delay. Set it to 0 to disable both the snap and the pop-out gestures entirely.' },
+            { section: 'Tabs', title: 'Tab windows together',
+              body: 'Alt-drag one window onto another to stack them as tabs sharing one tile, or right-click a title bar for a tab action. Click a tab in the tile\'s tab strip to switch between them.' },
+            { section: 'Tabs', title: 'Untab a window',
+              body: 'Drag a tab out of the tab strip to give it its own tile again, or use the title-bar / tab context menu.' },
+            { section: 'Splits', title: 'Split side-by-side',
+              body: 'Drag a window onto the LEFT or RIGHT interior of another window to split that tile horizontally, placing the two side-by-side. Drag the gutter between panes to resize them.' },
+            { section: 'Splits', title: 'Un-split',
+              body: 'Use the window context menu to merge a split back together, or just drag a pane somewhere else.' },
+            { section: 'Stacks & rows', title: 'Stack windows as rows',
+              body: 'Drag a window onto another window\'s TOP or BOTTOM edge to stack them as rows within the same column. Drag the horizontal gutter to resize the rows.' },
+            { section: 'Columns & widths', title: 'Column width presets',
+              body: 'A tiled column can be sized to 1/3, 1/2, 2/3, or max width from the window context menu or width controls.' },
+            { section: 'Columns & widths', title: 'Move & focus columns',
+              body: 'Move the focused column left/right, and jump focus between columns, with the move-column / focus-column shortcuts. Drag a column\'s side gutter to resize it.' },
+            { section: 'Drag-to-merge drop zones', title: 'Drop-zone cheat sheet',
+              body: 'While dragging, a highlighted overlay previews where the window will land: a column\'s far left/right edge = a NEW column; a window\'s top band = TAB into that tile; its interior left/right/top/bottom quadrants = a SPLIT; the bottom band of the desktop = FLOAT.' },
+            { section: 'Workspaces', title: 'Switch workspaces',
+              body: 'Click a pager dot at the bottom of the taskbar, or use the previous/next and "go to workspace 1-5" shortcuts. Each workspace is its own virtual desktop of windows.' },
+            { section: 'Workspaces', title: 'Send a window to a workspace',
+              body: 'Right-click a window or its taskbar item to send it to another workspace (or a new one). "On all workspaces" keeps a floating window visible on every workspace.' },
+            { section: 'Workspaces', title: 'Rename / remove a workspace',
+              body: 'Right-click a pager dot to rename or remove that workspace.' },
+            { section: 'Taskbar', title: 'Taskbar items',
+              body: 'Each open window has a taskbar button: click to focus and raise it (or restore it if minimized); right-click for per-window actions. Items for windows on other workspaces dim or hide (a Control Panel toggle).' },
+            { section: 'Taskbar', title: 'Launch button (+)',
+              body: 'Left-click the + to launch the default terminal; right-click it for the full profile / app menu. Its label is configurable under Control Panel -> Start button.' },
+            { section: 'Taskbar', title: 'Fullscreen & clock',
+              body: 'The fullscreen button toggles the browser into fullscreen. The optional clock chip shows the date & time (Control Panel -> Date & time).' },
+            { section: 'Floating window controls', title: 'Move & resize',
+              body: 'Drag a floating window\'s title bar to move it; drag its edges or corners to resize.' },
+            { section: 'Floating window controls', title: 'Minimize, close, terminate',
+              body: 'Minimize hides a window to the taskbar (Restore brings it back). Close is SOFT: closing a terminal leaves its shell running so you can reattach later; closing an app window (note/editor/file manager) keeps its saved document. Terminate (terminals only) hard-kills the shell process tree; Delete (app windows) discards the document for good. These are on the title-bar right-click menu.' },
+            { section: 'Floating window controls', title: 'Pin a window (lock to screen)',
+              body: 'A floating window\'s right-click menu has "Lock to screen (pin)": a pinned window stays put and does NOT scroll away with the tiling strip. (It pins position, not always-on-top.) "Unlock (scroll with strip)" reverses it.' },
+            { section: 'Floating window controls', title: 'Color & rename',
+              body: 'Recolor a window from the color button in its title bar (palette, custom, and recents). Double-click an app window\'s title to rename it.' },
+            { section: 'Window types & launching', title: 'Window types',
+              body: 'From the + menu you can open a terminal, a sticky note, a CodeMirror text editor, a file manager, and a task manager.' },
+            { section: 'Window types & launching', title: 'Terminals & working directory',
+              body: 'A terminal runs a shell on its broker host. The file manager and text editor open at the ACTIVE terminal\'s working directory and host, so they follow where you are.' },
+            { section: 'Hosts & multi-browser', title: 'Add a remote host',
+              body: 'Control Panel -> Hosts: enter a label, the broker URL, and its password (the broker\'s configured auth/MCP token). Each added host gets its own settings tab.' },
+            { section: 'Hosts & multi-browser', title: 'Host status chips',
+              body: 'A host\'s status chip shows ok / down / auth-needed / lease state. If it needs auth, re-enter the password to reconnect.' },
+            { section: 'Hosts & multi-browser', title: 'Single active browser (lease)',
+              body: 'Only one browser at a time is the active writer of a broker\'s layout (a lease). Another browser can take over with the "become active" prompt.' },
+            { section: 'MCP access', title: 'Per-window MCP access',
+              body: 'Each terminal\'s robot button sets that window\'s MCP access for agents: off, read, or read-write. The robot icon briefly flashes when an agent reads the screen or types into the terminal.' },
+            { section: 'MCP access', title: 'Enable MCP for a host',
+              body: 'Turn MCP on (and optionally allow launching terminals via MCP) per host in Control Panel -> MCP. A token authenticates the agent.' },
+            { section: 'Context menus', title: 'Right-click menus',
+              body: 'Right-click a window title bar, a taskbar item, a pager dot, the empty desktop, or the launch button to reach context actions: float/tile, tab/untab/un-split, stack & move columns, width presets, send-to-workspace, MCP access, arrange & lock-size, and more.' },
+            { section: 'Arrange & size (floating)', title: 'Arrange all floating windows',
+              body: 'Right-click the empty desktop in floating mode for one-shot arrangements: Cascade, Tile Horizontally, Tile Vertically, Tile H + V, and Minimize All Windows. The most recent arrange can be reversed with the "Undo <action>" item that appears afterward (single-level).' },
+            { section: 'Arrange & size (floating)', title: 'Lock window size',
+              body: 'The desktop right-click menu has a global "Lock Size" toggle: it snaps every floating window to the default size and hides the resize handles so windows can\'t be resized. "Unlock Size" restores free resizing.' },
+        ];
+        // Assemble the live corpus: static prose + generated entries, then cache
+        // a lower-cased haystack on each for the substring filter.
+        function buildHelpEntries() {
+            const entries = HELP_ENTRIES_STATIC.slice();
+            try {
+                const map = (getSettings().keybindings) || {};
+                for (const act of KEY_ACTIONS) {
+                    const combo = map[act.id] || '';
+                    entries.push({
+                        section: 'Keyboard shortcuts', title: act.label,
+                        body: combo ? ('Bound to ' + combo + '.')
+                            : 'Unbound - assign a key in Control Panel -> Keyboard shortcuts.',
+                        keys: combo || '',
+                    });
+                }
+            } catch (_) {}
+            try {
+                const pc = profilesCache.get(localHost().id);
+                if (pc && Array.isArray(pc.profiles) && pc.profiles.length) {
+                    const names = pc.profiles
+                        .map(p => (typeof p === 'string' ? p : (p && (p.name || p.id))))
+                        .filter(Boolean);
+                    if (names.length) entries.push({
+                        section: 'Launching', title: 'Terminal profiles (this host)',
+                        body: 'The + menu can launch: ' + names.join(', ') + '.'
+                            + (pc.default ? ' Default profile: ' + pc.default + '.' : ''),
+                    });
+                }
+            } catch (_) {}
+            try {
+                const m = mcpConfigCache.get(localHost().id);
+                if (m) entries.push({
+                    section: 'MCP access', title: 'MCP status (this host)',
+                    body: 'MCP is currently ' + (m.enabled ? 'ENABLED' : 'disabled')
+                        + '; default mode for new windows: ' + (m.default_mode || 'off')
+                        + '; launching via MCP is ' + (m.allow_launch ? 'allowed' : 'blocked')
+                        + '. Change these in Control Panel -> MCP.',
+                });
+            } catch (_) {}
+            for (const e of entries) {
+                e._hay = ((e.title || '') + ' ' + (e.body || '') + ' '
+                    + (e.section || '') + ' ' + (e.keys || '')).toLowerCase();
+            }
+            return entries;
+        }
+        // Render (filtered) entries grouped by section, in first-seen order, with
+        // textContent only (no innerHTML) like renderKeybindings.
+        function renderHelp(query) {
+            const q = (query || '').trim().toLowerCase();
+            const entries = _helpCorpus.filter(e => !q || (e._hay || '').indexOf(q) !== -1);
+            helpResultsEl.textContent = '';
+            if (!entries.length) { helpEmptyEl.style.display = ''; return; }
+            helpEmptyEl.style.display = 'none';
+            const order = [];
+            const bySection = new Map();
+            for (const e of entries) {
+                if (!bySection.has(e.section)) { bySection.set(e.section, []); order.push(e.section); }
+                bySection.get(e.section).push(e);
+            }
+            for (const sec of order) {
+                const secDiv = document.createElement('div');
+                secDiv.className = 'help-section';
+                const title = document.createElement('div');
+                title.className = 'help-section-title';
+                title.textContent = sec;
+                secDiv.appendChild(title);
+                for (const e of bySection.get(sec)) {
+                    const ent = document.createElement('div');
+                    ent.className = 'help-entry';
+                    const t = document.createElement('div');
+                    t.className = 'h-title';
+                    t.textContent = e.title;
+                    ent.appendChild(t);
+                    if (e.body) {
+                        const b = document.createElement('div');
+                        b.className = 'h-body';
+                        b.textContent = e.body;
+                        ent.appendChild(b);
+                    }
+                    if (e.keys) {
+                        const k = document.createElement('div');
+                        k.className = 'h-keys';
+                        k.textContent = e.keys;
+                        ent.appendChild(k);
+                    }
+                    secDiv.appendChild(ent);
+                }
+                helpResultsEl.appendChild(secDiv);
+            }
+        }
+        function markHelpSeen() {
+            try {
+                const s = getSettings();
+                if (!s.helpHintSeen) { s.helpHintSeen = true; savePrefs(); }
+            } catch (_) {}
+        }
+        function openHelp() {
+            closeSettings();   // one modal at a time (avoid a settings+help stack)
+            helpSearchEl.value = '';
+            _helpCorpus = buildHelpEntries();     // snapshot live state once per open
+            renderHelp('');
+            helpOverlay.classList.add('open');
+            markHelpSeen();   // opening Help is the strongest "seen" signal
+            // Warm the generated entries that may be cold, then rebuild + re-render
+            // (preserving the current query) if still open.
+            const refresh = () => {
+                if (!helpOverlay.classList.contains('open')) return;
+                _helpCorpus = buildHelpEntries();
+                renderHelp(helpSearchEl.value);
+            };
+            try { fetchProfiles(localHost()).then(refresh).catch(() => {}); } catch (_) {}
+            try { fetchMcpConfig(localHost()).then(refresh).catch(() => {}); } catch (_) {}
+            setTimeout(() => { try { helpSearchEl.focus(); } catch (_) {} }, 0);
+        }
+        function closeHelp() {
+            if (helpOverlay) helpOverlay.classList.remove('open');
+        }
+        (function wireHelp() {
+            const chip = document.getElementById('help-chip');
+            if (chip) {
+                chip.addEventListener('click', openHelp);
+                chip.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openHelp(); }
+                });
+            }
+            helpSearchEl.addEventListener('input', () => renderHelp(helpSearchEl.value));
+            document.getElementById('help-close').addEventListener('click', closeHelp);
+            helpOverlay.addEventListener('mousedown', (e) => {
+                if (e.target === helpOverlay) closeHelp();
+            });
+        })();
+        // First-run nudge: once, point new users at the "?" chip (only if it's
+        // visible). Deferred until the initial /state has been ADOPTED so it
+        // reflects the synced helpHintSeen/showHelpButton rather than pre-pull
+        // defaults (codex); capped (~10s) so an offline/auth-blocked broker
+        // still nudges from local prefs instead of hanging forever.
+        let _helpHintTries = 0;
+        function maybeShowHelpHint() {
+            try {
+                if (!_stateReady && _helpHintTries++ < 20) {
+                    setTimeout(maybeShowHelpHint, 500);
+                    return;
+                }
+                const s = getSettings();
+                if (s.helpHintSeen || !s.showHelpButton) return;
+                showNotice('Tip: click the "?" on the taskbar for the interface guide.', 7000);
+                s.helpHintSeen = true;
+                savePrefs();
+            } catch (_) {}
+        }
+        setTimeout(maybeShowHelpHint, 1800);
 
         // Build the tab bar: a "Browser" tab (connection list) + one tab per
         // configured host. Active tab highlighted.
@@ -13815,6 +14205,7 @@
             setPatternEl.value = ls.pattern;
             setTermFontEl.value = ls.termFont || '';   // #18 (browser-global)
             setClockEl.checked = !!ls.clock;
+            setHelpButtonEl.checked = !!ls.showHelpButton;   // #40 (browser-global)
             setStartLabelEl.value = (ls.startLabel === '+' ? '' : ls.startLabel);
             // Default start path is PER-HOST (#17): read the target host's own
             // settings (local = live getSettings(); remote = its cached blob),
@@ -14130,6 +14521,11 @@
             getSettings().clock = !!setClockEl.checked;
             savePrefs();
             applyClock(setClockEl.checked);
+        });
+        setHelpButtonEl.addEventListener('change', () => {   // #40
+            getSettings().showHelpButton = !!setHelpButtonEl.checked;
+            savePrefs();
+            applyHelpButton(setHelpButtonEl.checked);
         });
         const commitStartLabel = () => {
             const v = (setStartLabelEl.value || '').trim().slice(0, 24) || '+';


### PR DESCRIPTION
Closes #40.

## What
Browserland has many powerful but **undiscoverable** interactions — hold-to-snap, drag-to-tab/split, the tile→float pop-out, workspaces, pin, per-window MCP, remote hosts. None of it was explained inside the app. This adds an in-app **searchable Help overlay** opened from a **"?" chip** on the taskbar.

## UI
- A **"?" chip** mounts next to `#clock-chip` (shown via an `.on` class, same pattern as the clock). Click it — or focus + Enter/Space — to open a modal that mirrors the Control Panel's overlay / `.set-*` chrome.
- One **search box** filters a structured corpus by **case-insensitive substring** over `title + body + section + keys`, re-rendered **grouped by section** with a **"no matches"** state (rendered with `textContent` only).
- Closes on the **Close** button, a **backdrop** click, and **Escape** (the existing global Escape handler now also closes Help). **Opening Help closes the Control Panel** so the two never stack.

## Content (~55 entries)
- **~35 static** plain-language entries covering every feature in the issue: layout modes, hold-to-snap + the #38 pop-out, tabs, splits, stacks, columns/widths, the **drag-drop drop zones**, workspaces, the taskbar, floating-window controls, window types, hosts / multi-browser, MCP, context menus, and arrange & size.
- **Generated from live state** so they never go stale: the **keyboard-shortcuts cheat-sheet** from `KEY_ACTIONS × live keybindings` (tracks rebinds), the local **launch profiles**, and the local **MCP status**. The corpus is snapshotted **once per open** (and rebuilt when a cold profiles/MCP cache warms), then filtered per keystroke.

## Toggle, hotkey, nudge
- A browser-global **"Show help (?) button"** checkbox (default **on**) follows the `#set-clock` path end-to-end: `normalizeSettings` default, `renderSettings` read, change-listener → `savePrefs` + `applyHelpButton`, and `applyHelpButton` called from `applyThemeSettings` so it converges on boot and every `/state` pull.
- A **`toggle-help`** action is added to `KEY_ACTIONS` but **left out of `DEFAULT_KEYBINDINGS`**, so it shows in the keybindings editor as **unbound** and is bindable.
- A one-time **first-run nudge** (`helpHintSeen`) points new users at the chip; it waits for the initial `/state` to be adopted (reflecting synced flags, not pre-pull defaults) and is capped so an offline broker still nudges from local prefs.

## Adversarial review (codex) — adopted
- **Corrected several help entries that did not match the actual code** (verified against the menus): pinning is *scroll-lock*, not always-on-top; the old "save/restore layouts" is really the desktop **Cascade / Tile / Undo** arrange; **Lock Size** is a *global desktop-menu* toggle; terminal **Close** detaches (shell keeps running) vs app **Close** keeps the document (with a separate Delete).
- **Defer the nudge** until `/state` is ready; **openHelp closes settings** + a help `z-index` above settings; a **defensive empty-haystack** guard.
- *Dismissed:* storing the toggle/flag in the synced settings blob — that's the issue's explicit spec ("rides the existing prefs / /state sync", "a flag in settings"), mirroring the `clock` setting.

## Tests — real `:4446` broker via Playwright
Chip visible by default; opens / searches / closes (button, backdrop, Escape) cleanly; **case-insensitive** filter + **no-match** state; generated **shortcuts reflect live bindings** (`toggle-help` shown unbound); the Control Panel **toggle hides/shows the chip and persists**; the **`toggle-help` hotkey** is bindable and toggles; the **first-run nudge** fires once and sets the flag; **openHelp closes the Control Panel**; console clean. **Full pytest suite green: 428 passed, 11 skipped.** No server/protocol changes; no new dependencies.

## Affected files
`webterm/broker/index.html`.
