### PR TITLE
fix(agent): report the foreground agent's cwd, not the shell's (#47)

### DIFF
--- a/tests/test_backend_procs.py
+++ b/tests/test_backend_procs.py
@@ -4,8 +4,10 @@ a throwaway child process; they must NEVER touch a pid outside the session
 tree (notably the test runner itself)."""
 
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 
 import pytest
@@ -111,3 +113,198 @@ def test_session_root_identity_guard():
         assert child.poll() is None
     finally:
         child.kill()
+
+
+# -- agent-aware cwd (issue #47) ---------------------------------------------
+# The session shell can sit a level *above* where the agent (Claude Code etc.)
+# actually runs; cwd() must report the AGENT's working dir, not the shell's, so
+# the "edit AGENTS.md for this folder" button opens the right place.
+
+
+def _kill_tree(pid):
+    """Best-effort: kill `pid` and every descendant so no sleeper outlives the
+    test (and so a child's cwd no longer pins a temp dir on Windows)."""
+    try:
+        proc = psutil.Process(pid)
+    except Exception:
+        return
+    for child in (proc.children(recursive=True) or []):
+        try:
+            child.kill()
+        except Exception:
+            pass
+    try:
+        proc.kill()
+    except Exception:
+        pass
+
+
+def _spawn_shell_with_agent(shell_dir, agent_dir):
+    """A 'shell' sleeper running in `shell_dir` that spawns a child whose argv[0]
+    is 'claude' (so classify_proc tags it the agent) running in `agent_dir`.
+    Mirrors the #47 repro: shell in the parent, agent in a subdir."""
+    shell_code = (
+        "import subprocess, sys, time\n"
+        "subprocess.Popen(['claude', '-c', 'import time; time.sleep(60)'], "
+        f"executable=sys.executable, cwd={agent_dir!r})\n"
+        "time.sleep(60)\n"
+    )
+    return subprocess.Popen([sys.executable, "-c", shell_code], cwd=shell_dir)
+
+
+def test_cwd_prefers_foreground_agent_subdir():
+    shell_dir = tempfile.mkdtemp()
+    agent_dir = tempfile.mkdtemp(dir=shell_dir)  # a subdir of the shell's cwd
+    shell = None
+    try:
+        shell = _spawn_shell_with_agent(shell_dir, agent_dir)
+        be = _StubBackend()
+        be.pid = shell.pid
+        # Wait for the 'claude' grandchild to come up and be classified; until
+        # then cwd() correctly falls back to the shell dir.
+        got = None
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            got = be.cwd()
+            if got and os.path.exists(got) and os.path.samefile(got, agent_dir):
+                break
+            time.sleep(0.1)
+        assert got is not None, "cwd() returned None for a live session"
+        assert os.path.samefile(got, agent_dir), (
+            f"cwd() = {got!r}; expected the agent's dir {agent_dir!r}, "
+            f"not the shell's {shell_dir!r}"
+        )
+        assert not os.path.samefile(got, shell_dir)
+    finally:
+        if shell is not None:
+            _kill_tree(shell.pid)
+        shutil.rmtree(agent_dir, ignore_errors=True)
+        shutil.rmtree(shell_dir, ignore_errors=True)
+
+
+def test_cwd_falls_back_to_shell_when_no_agent():
+    shell_dir = tempfile.mkdtemp()
+    shell = None
+    try:
+        # A plain sleeper -> classify_proc finds no agent -> shell's cwd.
+        shell = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"], cwd=shell_dir)
+        be = _StubBackend()
+        be.pid = shell.pid
+        got = be.cwd()
+        assert got is not None and os.path.samefile(got, shell_dir), (
+            f"cwd() = {got!r}; expected the shell dir {shell_dir!r}")
+    finally:
+        if shell is not None:
+            _kill_tree(shell.pid)
+        shutil.rmtree(shell_dir, ignore_errors=True)
+
+
+def test_cwd_none_without_session():
+    be = _StubBackend()
+    be.pid = None
+    assert be.cwd() is None
+
+
+def test_cwd_respects_session_root_identity_guard():
+    """A recycled session-root PID (create_time mismatch) makes cwd() return
+    None, just like enumerate/kill — it never reads a stranger's cwd."""
+    child = _spawn_sleeper()
+    try:
+        be = _StubBackend()
+        be.pid = child.pid
+        be.note_session_started()
+        assert be.cwd() is not None  # resolves normally
+        be._root_ctime = be._root_ctime + 10000.0  # simulate PID reuse
+        assert be.cwd() is None
+    finally:
+        child.kill()
+
+
+def test_cwd_picks_shallowest_agent():
+    """With agents at two depths, the one CLOSEST to the shell (the session's
+    primary) wins — a deeper nested agent must not hijack the reported cwd."""
+    base = tempfile.mkdtemp()
+    dir_shallow = tempfile.mkdtemp(dir=base)
+    dir_deep = tempfile.mkdtemp(dir=base)
+    shell = None
+    try:
+        # A non-agent intermediate that owns the DEEP agent (grandchild of shell).
+        inter_code = (
+            "import subprocess, sys, time\n"
+            "subprocess.Popen(['claude', '-c', 'import time; time.sleep(60)'], "
+            f"executable=sys.executable, cwd={dir_deep!r})\n"
+            "time.sleep(60)\n"
+        )
+        shell_code = (
+            "import subprocess, sys, time\n"
+            # SHALLOW agent: a direct child of the shell (depth 1).
+            "subprocess.Popen(['claude', '-c', 'import time; time.sleep(60)'], "
+            f"executable=sys.executable, cwd={dir_shallow!r})\n"
+            # DEEP agent: under a non-agent intermediate (depth 2).
+            f"subprocess.Popen([sys.executable, '-c', {inter_code!r}])\n"
+            "time.sleep(60)\n"
+        )
+        shell = subprocess.Popen([sys.executable, "-c", shell_code], cwd=base)
+        be = _StubBackend()
+        be.pid = shell.pid
+        got = None
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            got = be.cwd()
+            if got and os.path.exists(got) and os.path.samefile(got, dir_shallow):
+                break
+            time.sleep(0.1)
+        assert got is not None and os.path.samefile(got, dir_shallow), (
+            f"cwd() = {got!r}; expected the shallow agent dir {dir_shallow!r}, "
+            f"not the deep one {dir_deep!r}")
+    finally:
+        if shell is not None:
+            _kill_tree(shell.pid)
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def test_cwd_none_when_detected_agent_cwd_unreadable(monkeypatch):
+    """If an agent IS detected but its cwd can't be read (denied / mid-exit
+    race), cwd() returns None to preserve the last-known dir — it must NOT fall
+    back to the shell's cwd, which is the known-wrong parent in the #47 case."""
+    shell_dir = tempfile.mkdtemp()
+    agent_dir = tempfile.mkdtemp(dir=shell_dir)
+    shell = None
+    try:
+        shell = _spawn_shell_with_agent(shell_dir, agent_dir)
+        be = _StubBackend()
+        be.pid = shell.pid
+        # Wait until the agent is up and normally resolvable.
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            c = be.cwd()
+            if c and os.path.exists(c) and os.path.samefile(c, agent_dir):
+                break
+            time.sleep(0.1)
+        # Locate the 'claude' grandchild so we can deny only ITS cwd.
+        agent_pid = None
+        for p in (psutil.Process(shell.pid).children(recursive=True) or []):
+            try:
+                cl = p.cmdline()
+            except Exception:
+                continue
+            if cl and os.path.basename(cl[0]).lower().startswith("claude"):
+                agent_pid = p.pid
+                break
+        assert agent_pid is not None, "agent grandchild never appeared"
+        real_cwd = psutil.Process.cwd
+
+        def fake_cwd(self):
+            if self.pid == agent_pid:
+                raise psutil.AccessDenied(agent_pid)
+            return real_cwd(self)
+
+        monkeypatch.setattr(psutil.Process, "cwd", fake_cwd)
+        # Agent detected, agent.cwd() denied -> None, NOT the shell's parent dir.
+        assert be.cwd() is None
+    finally:
+        if shell is not None:
+            _kill_tree(shell.pid)
+        shutil.rmtree(agent_dir, ignore_errors=True)
+        shutil.rmtree(shell_dir, ignore_errors=True)

--- a/webterm/agent/agent.py
+++ b/webterm/agent/agent.py
@@ -302,9 +302,11 @@ class Agent:
                 # carries the current agent; then push the live frame.
                 self.state.agent = new
                 self._enqueue("txt", protocol.agent_frame(new))
-            # Live cwd (best-effort): the shell's working dir, so the AGENTS.md
-            # button tracks a `cd`. State updates before the frame (reconnect
-            # hello accuracy), same as agent above. Errors are swallowed by the
+            # Live cwd (best-effort): the foreground agent's working dir (the
+            # shell's as fallback), so the AGENTS.md button tracks where the
+            # agent actually runs even when the shell sits a level up (#47), and
+            # follows a `cd`. State updates before the frame (reconnect hello
+            # accuracy), same as agent above. Errors are swallowed by the
             # backend (returns None), so a denied/dead process never blanks it.
             try:
                 cwd = await loop.run_in_executor(None, self.backend.cwd)

--- a/webterm/agent/backends/base.py
+++ b/webterm/agent/backends/base.py
@@ -17,6 +17,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
+from ..detect import _safe_exe, classify_proc
+
 LOGGER = logging.getLogger(__name__)
 
 # Caps for the task-manager process list (DoS / privacy bounds): never report
@@ -82,9 +84,71 @@ class PtyBackend(ABC):
         return None
 
     def cwd(self) -> Optional[str]:
-        """Best-effort: the shell's current working directory, or None. Like
-        ``foreground_command`` this runs on a periodic timer and must NEVER
-        raise. The default knows nothing; platform backends override it."""
+        """Best-effort working directory for this session's file tools, or None.
+
+        Prefer the AGENT'S own cwd (Claude Code / codex / grok / opencode) over
+        the shell's: the agent can run in a *subdir* of where the session shell
+        sits, in which case the shell's cwd points a level too high and the
+        "edit AGENTS.md for this folder" button opens the wrong place (issue
+        #47). We BFS the session tree and pick the agent CLOSEST to the shell
+        (the session's primary, so a deeper/nested agent can't win), and report
+        its cwd.
+
+        Fallback rules matter: if an agent IS detected but its cwd can't be read
+        (denied / mid-exit race), we return None — NOT the shell's cwd — so the
+        caller keeps the last-known agent dir instead of flapping to the
+        known-wrong parent. Only a session with NO agent at all falls back to
+        the shell's own cwd (a plain shell, where that IS the right answer).
+
+        Unlike ``foreground_command`` this is deliberately NOT foreground-group
+        filtered — the agent's working dir should stay stable even while it runs
+        a foreground child (a build, a Bash tool call). Runs on a periodic
+        timer; like ``foreground_command`` it must NEVER raise."""
+        shell = self._session_root()
+        if shell is None:
+            return None
+        agent = self._find_session_agent(shell)
+        if agent is not None:
+            # Agent known: its cwd, or None to preserve the last-known dir. We
+            # never fall through to the shell here -- in the #47 case the shell
+            # sits a level up, so reporting it would re-introduce the bug.
+            # (A descendant PID could in theory be recycled between classify and
+            # this read; the window is sub-tick and self-corrects next tick.)
+            try:
+                cwd = agent.cwd()
+            except Exception:
+                cwd = None
+            return cwd or None
+        # No agent in the tree -> a plain shell session; the shell's own cwd is
+        # the right answer (and tracks the user's `cd`).
+        try:
+            return shell.cwd() or None
+        except Exception:
+            return None
+
+    def _find_session_agent(self, shell):
+        """The ``psutil.Process`` of the agent CLOSEST to the session ``shell``
+        (breadth-first, so the session's primary agent wins over a deeper nested
+        one), or None. Bounded by ``_MAX_PROCS`` against a fork-bomb; a denied or
+        vanished process is skipped, never fatal. Never raises."""
+        seen: set = set()
+        level = [shell]
+        while level and len(seen) < _MAX_PROCS:
+            nxt = []
+            for proc in level:
+                if proc.pid in seen:
+                    continue
+                seen.add(proc.pid)
+                try:
+                    if classify_proc(proc.name(), proc.cmdline(), _safe_exe(proc)):
+                        return proc
+                except Exception:
+                    pass
+                try:
+                    nxt.extend(proc.children())
+                except Exception:
+                    pass
+            level = nxt
         return None
 
     # -- task manager: process tree + scoped kill ---------------------------

--- a/webterm/agent/backends/linux_pty.py
+++ b/webterm/agent/backends/linux_pty.py
@@ -21,18 +21,10 @@ import termios
 import time
 from typing import Callable, Mapping, Optional, Sequence, Tuple
 
-from ..detect import classify_proc
+from ..detect import _safe_exe, classify_proc
 from .base import PtyBackend
 
 _READ_SIZE = 64 * 1024
-
-
-def _safe_exe(proc) -> Optional[str]:
-    """``proc.exe()`` or None — it raises AccessDenied/ZombieProcess often."""
-    try:
-        return proc.exe()
-    except Exception:
-        return None
 
 
 def _proc_state(pid: int) -> Optional[str]:
@@ -307,16 +299,10 @@ class LinuxPtyBackend(PtyBackend):
                 return agent
         return None
 
-    def cwd(self) -> Optional[str]:
-        """The shell's current working directory via psutil, tracking the
-        user's ``cd``. Never raises."""
-        if self.pid is None:
-            return None
-        try:
-            import psutil
-            return psutil.Process(self.pid).cwd()
-        except Exception:
-            return None
+    # ``cwd()`` is inherited from PtyBackend: it reports the foreground agent's
+    # own working dir (falling back to the shell), so the AGENTS.md button opens
+    # the dir the agent actually runs in even when the shell sits a level up
+    # (issue #47).
 
     # -- psutil-free destroy-window fallback -----------------------------
 

--- a/webterm/agent/backends/win_conpty.py
+++ b/webterm/agent/backends/win_conpty.py
@@ -37,18 +37,10 @@ from typing import Callable, Mapping, Optional, Sequence
 from winpty import PTY  # type: ignore
 from winpty.enums import Backend  # type: ignore
 
-from ..detect import classify_proc
+from ..detect import _safe_exe, classify_proc
 from .base import PtyBackend
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _safe_exe(proc) -> Optional[str]:
-    """``proc.exe()`` or None — it raises AccessDenied/ZombieProcess often."""
-    try:
-        return proc.exe()
-    except Exception:
-        return None
 
 
 def _auto_backend() -> int:
@@ -253,16 +245,10 @@ class WinConPtyBackend(PtyBackend):
                 return agent
         return None
 
-    def cwd(self) -> Optional[str]:
-        """The spawned shell's current working directory via psutil. ``PTY.pid``
-        is the shell itself, so its cwd tracks the user's ``cd``. Never raises."""
-        if self.pid is None:
-            return None
-        try:
-            import psutil
-            return psutil.Process(self.pid).cwd()
-        except Exception:
-            return None
+    # ``cwd()`` is inherited from PtyBackend: it reports the foreground agent's
+    # own working dir (falling back to the shell), so the AGENTS.md button opens
+    # the dir Claude Code actually runs in even when the shell sits a level up
+    # (issue #47).
 
     # NOTE: no ``kill_proc_fallback`` override here -> inherits the base hook,
     # so destroying a window without psutil still returns "psutil_unavailable"

--- a/webterm/agent/detect.py
+++ b/webterm/agent/detect.py
@@ -41,6 +41,16 @@ _VENDOR_DIRS = {
 }
 
 
+def _safe_exe(proc) -> Optional[str]:
+    """``proc.exe()`` or None — psutil raises AccessDenied/ZombieProcess for it
+    often. A best-effort hint for ``classify_proc``'s exe/vendor-dir rules; the
+    PTY backends pass it when walking the session's process tree."""
+    try:
+        return proc.exe()
+    except Exception:
+        return None
+
+
 def _norm(token: str) -> str:
     """Basename, lowercased, with a single known launcher extension stripped."""
     b = os.path.basename(str(token)).lower()


### PR DESCRIPTION
Closes #47.

The 📋 "edit AGENTS.md for this folder" button (and the file tools) opened the **parent** of the session's real working dir on Windows. Root cause confirmed live: a session's reported cwd came from the **shell** process, but Claude Code / codex / etc. often run in a *subdir* of the shell's cwd — e.g. shell `X:\Data`, agent `X:\Data\<project>`.

The session now reports the **foreground agent's** own cwd: BFS the session tree, pick the agent closest to the shell (so a nested agent can't hijack it), report its cwd; fall back to the shell only when there is no agent, and return `None` (keep last-known) rather than the wrong parent if a detected agent's cwd can't be read. `_safe_exe` moves to `detect.py`; the agent-aware `cwd()` lives on the base `PtyBackend` (both backends inherit it).

Tests: agent-in-subdir, shallowest-agent selection, no-agent fallback, identity guard, unreadable-agent-cwd. Full suite green.