### PR TITLE
#72: richer file-manager right-click menu + drag between managers

### DIFF
--- a/tests/test_broker_e2e.py
+++ b/tests/test_broker_e2e.py
@@ -883,8 +883,8 @@ def test_file_read_b64_binary(broker_proc, tmp_path):
 
 
 def test_file_delete(broker_proc, tmp_path):
-    """#46: /file/delete removes a single FILE (the delete-source step of a
-    cross-pane Move); refuses a directory so it can never recurse a tree;
+    """#46/#72: /file/delete removes a single FILE; a directory needs
+    recursive=true (else is_a_directory, so a mis-click can't wipe a tree);
     404s a missing path; bad_path on a blank path."""
     _, _, base = broker_proc
     auth = {"Authorization": f"Bearer {TOKEN}",
@@ -905,12 +905,18 @@ def test_file_delete(broker_proc, tmp_path):
     st, r = _post("/file/delete", {"path": str(f)})
     assert st == 404 and r["error"] == "not_found", r
 
-    # A directory is refused outright — delete is FILE-only by design.
+    # A directory without recursive is refused (#72) — no accidental tree wipe.
     d = tmp_path / "adir"
     d.mkdir()
+    (d / "child.txt").write_text("x", encoding="utf-8")
     st, r = _post("/file/delete", {"path": str(d)})
-    assert st == 400 and r["error"] == "not_a_file", r
+    assert st == 400 and r["error"] == "is_a_directory", r
     assert d.exists()
+
+    # ...but recursive=true removes the whole tree (#72).
+    st, r = _post("/file/delete", {"path": str(d), "recursive": True})
+    assert st == 200 and r["ok"], r
+    assert not d.exists()
 
     # A blank path -> bad_path (mirrors the other /file/* handlers).
     st, r = _post("/file/delete", {"path": ""})

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -561,3 +561,38 @@ def test_unzip_traversal_member_stays_in_dest(tmp_path, monkeypatch):
     assert not (tmp_path / "escape.txt").exists()    # did NOT escape
     assert (tmp_path / "out" / "escape.txt").read_text(
         encoding="utf-8") == "pwned"
+
+
+# --------------------------------------------------------------------------- #
+# /file/stat (#72)
+# --------------------------------------------------------------------------- #
+
+def test_stat_file(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("hello", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/stat", json={"path": "a.txt"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert r.json["type"] == "file"
+    assert r.json["size"] == 5
+    assert isinstance(r.json["mtime"], (int, float))
+    assert isinstance(r.json["mode"], int)
+    assert "children" not in r.json
+
+
+def test_stat_dir_has_child_count(tmp_path, monkeypatch):
+    d = tmp_path / "d"
+    d.mkdir()
+    (d / "a").write_text("a", encoding="utf-8")
+    (d / "b").write_text("b", encoding="utf-8")
+    (d / "sub").mkdir()
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/stat", json={"path": "d"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert r.json["type"] == "dir"
+    assert r.json["children"] == 3
+
+
+def test_stat_missing_404(tmp_path, monkeypatch):
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/stat", json={"path": "nope"})
+    assert r.status == 404 and r.json["error"] == "not_found"

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -10,9 +10,90 @@ from pathlib import Path
 
 import pytest
 
-from webterm.broker.app import _resolve_host_path
+from webterm.broker.app import _resolve_host_path, create_app
 
 WIN = sys.platform == "win32"
+
+
+# --------------------------------------------------------------------------- #
+# /file/* handler tests (#72) — driven through the in-process Sanic test client
+# --------------------------------------------------------------------------- #
+# Each create_app needs a UNIQUE Sanic name (Sanic refuses two same-named apps
+# in one process). editor_root points at tmp_path so a relative body path
+# resolves into the test's sandbox; state_path keeps the identity/state files
+# out of the repo. No token => a loopback request (the test client dials
+# 127.0.0.1) passes the gate.
+_app_seq = 0
+
+
+def _make_file_app(tmp_path, monkeypatch, token=None):
+    global _app_seq
+    _app_seq += 1
+    monkeypatch.delenv("WEB_TERMINAL_TOKEN", raising=False)
+    cfg = {"editor_root": str(tmp_path),
+           "state_path": str(tmp_path / "webterm_state.json")}
+    if token:
+        cfg["auth_token"] = token
+    return create_app(cfg, name=f"webterm-file-test-{_app_seq}")
+
+
+# ---- /file/mkdir ---------------------------------------------------------
+
+def test_mkdir_creates_dir(tmp_path, monkeypatch):
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/mkdir", json={"path": "newdir"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert (tmp_path / "newdir").is_dir()
+
+
+def test_mkdir_existing_is_conflict(tmp_path, monkeypatch):
+    (tmp_path / "d").mkdir()
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/mkdir", json={"path": "d"})
+    assert r.status == 409 and r.json["error"] == "exists"
+
+
+def test_mkdir_parent_missing(tmp_path, monkeypatch):
+    # os.mkdir, not makedirs: the missing intermediate parents are NOT created.
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/mkdir",
+                                json={"path": "no/such/parent/leaf"})
+    assert r.status == 400 and r.json["error"] == "parent_missing"
+    assert not (tmp_path / "no").exists()
+
+
+def test_mkdir_bad_path(tmp_path, monkeypatch):
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/mkdir", json={"path": ""})
+    assert r.status == 400 and r.json["error"] == "bad_path"
+
+
+# ---- cross-cutting route guard (#72 P2-3) --------------------------------
+
+def test_every_file_route_has_options_and_enforces_auth(tmp_path, monkeypatch):
+    # Every POST /file/* route must (a) carry a matching OPTIONS preflight — a
+    # missing one silently 405s every cross-origin (remote-pane) call — and (b)
+    # enforce the token gate (401 when a token is configured and absent).
+    # Enumerated from the LIVE router so a future endpoint can't skip the guard.
+    app = _make_file_app(tmp_path, monkeypatch, token="sekrit")
+    posts, options = set(), set()
+    for route in app.router.routes:
+        path = "/" + route.path.lstrip("/")
+        if not path.startswith("/file/"):
+            continue
+        methods = set(route.methods or ())
+        if "OPTIONS" in methods:
+            options.add(path)
+        if methods - {"OPTIONS"}:
+            posts.add(path)
+    assert posts, "no /file/* POST routes discovered"
+    missing = posts - options
+    assert not missing, f"/file/* routes without an OPTIONS preflight: {sorted(missing)}"
+    for path in sorted(posts):
+        _, r = app.test_client.post(path, json={"path": "x"})
+        assert r.status == 401, f"{path} skipped the auth gate (got {r.status})"
+        _, r = app.test_client.options(path)
+        assert r.status == 204, f"{path} OPTIONS not 204 (got {r.status})"
 
 
 def test_empty_resolves_to_default(tmp_path):

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -7,10 +7,12 @@ half-absolute / ADS rejections an adversarial review (codex) flagged."""
 
 import os
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
 
+import webterm.broker.app as app_mod
 from webterm.broker.app import _resolve_host_path, create_app
 
 WIN = sys.platform == "win32"
@@ -433,3 +435,129 @@ def test_delete_symlink_to_file_unlinks_link_keeps_target(tmp_path, monkeypatch)
     assert r.status == 200 and r.json["ok"] is True
     assert not os.path.lexists(str(link))
     assert target.read_text(encoding="utf-8") == "precious"
+
+
+# --------------------------------------------------------------------------- #
+# /file/zip + /file/unzip (#72)
+# --------------------------------------------------------------------------- #
+
+def test_zip_file_then_unzip_roundtrip(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("hello", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/zip",
+                                json={"src": "a.txt", "dest": "a.zip"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert (tmp_path / "a.zip").is_file()
+    with zipfile.ZipFile(tmp_path / "a.zip") as zf:
+        assert zf.namelist() == ["a.txt"]
+    _, r = app.test_client.post("/file/unzip",
+                                json={"path": "a.zip", "dest": "out"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert (tmp_path / "out" / "a.txt").read_text(encoding="utf-8") == "hello"
+
+
+def test_zip_dir_then_unzip_roundtrip(tmp_path, monkeypatch):
+    src = tmp_path / "tree"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "f.txt").write_text("x", encoding="utf-8")
+    (src / "top.txt").write_text("t", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/zip",
+                                json={"src": "tree", "dest": "tree.zip"})
+    assert r.status == 200 and r.json["ok"] is True
+    # the archive carries the top folder name
+    with zipfile.ZipFile(tmp_path / "tree.zip") as zf:
+        names = set(zf.namelist())
+    assert any(n.startswith("tree/") for n in names)
+    _, r = app.test_client.post("/file/unzip",
+                                json={"path": "tree.zip", "dest": "out"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert (tmp_path / "out" / "tree" / "sub" / "f.txt").read_text(
+        encoding="utf-8") == "x"
+    assert (tmp_path / "out" / "tree" / "top.txt").read_text(
+        encoding="utf-8") == "t"
+
+
+def test_zip_dest_exists_409(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "a.zip").write_text("not really a zip", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/zip",
+                                json={"src": "a.txt", "dest": "a.zip"})
+    assert r.status == 409 and r.json["error"] == "exists"
+
+
+def test_zip_dest_overwrite_ok(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "a.zip").write_text("stale", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post(
+        "/file/zip", json={"src": "a.txt", "dest": "a.zip", "overwrite": True})
+    assert r.status == 200 and r.json["ok"] is True
+    with zipfile.ZipFile(tmp_path / "a.zip") as zf:   # a real archive now
+        assert zf.namelist() == ["a.txt"]
+
+
+def test_zip_too_many_entries_rejected(tmp_path, monkeypatch):
+    src = tmp_path / "tree"
+    src.mkdir()
+    (src / "a.txt").write_text("a", encoding="utf-8")
+    (src / "b.txt").write_text("b", encoding="utf-8")
+    monkeypatch.setattr(app_mod, "MAX_ARCHIVE_ENTRIES", 1)
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/zip",
+                                json={"src": "tree", "dest": "out.zip"})
+    assert r.status == 400 and r.json["error"] == "too_many_entries"
+    assert not (tmp_path / "out.zip").exists()       # no partial archive
+
+
+def test_zip_dest_in_source_rejected(tmp_path, monkeypatch):
+    (tmp_path / "tree").mkdir()
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/zip",
+                                json={"src": "tree", "dest": "tree/inner.zip"})
+    assert r.status == 400 and r.json["error"] == "dest_in_source"
+
+
+def test_unzip_dest_exists_409(tmp_path, monkeypatch):
+    with zipfile.ZipFile(tmp_path / "a.zip", "w") as zf:
+        zf.writestr("x.txt", "x")
+    (tmp_path / "out").mkdir()
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/unzip",
+                                json={"path": "a.zip", "dest": "out"})
+    assert r.status == 409 and r.json["error"] == "exists"
+
+
+def test_unzip_bad_zip(tmp_path, monkeypatch):
+    (tmp_path / "a.zip").write_text("not a zip at all", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/unzip",
+                                json={"path": "a.zip", "dest": "out"})
+    assert r.status == 400 and r.json["error"] == "bad_zip"
+    assert not (tmp_path / "out").exists()
+
+
+def test_unzip_zip_bomb_rejected(tmp_path, monkeypatch):
+    with zipfile.ZipFile(tmp_path / "big.zip", "w") as zf:
+        zf.writestr("a.txt", "x" * 1000)
+    monkeypatch.setattr(app_mod, "MAX_ARCHIVE_BYTES", 10)
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/unzip",
+                                json={"path": "big.zip", "dest": "out"})
+    assert r.status == 400 and r.json["error"] == "archive_too_large"
+    assert not (tmp_path / "out").exists()           # nothing extracted
+
+
+def test_unzip_traversal_member_stays_in_dest(tmp_path, monkeypatch):
+    # A malicious '../escape.txt' member must be sanitised to land UNDER dest by
+    # CPython's extractall — it must NOT escape to dest's parent.
+    with zipfile.ZipFile(tmp_path / "evil.zip", "w") as zf:
+        zf.writestr("../escape.txt", "pwned")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/unzip",
+                                json={"path": "evil.zip", "dest": "out"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not (tmp_path / "escape.txt").exists()    # did NOT escape
+    assert (tmp_path / "out" / "escape.txt").read_text(
+        encoding="utf-8") == "pwned"

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -5,6 +5,7 @@ browse the whole host (gated by the same auth as ``/launch``, which already
 grants shell-level filesystem access). These cover the resolution rules and the
 half-absolute / ADS rejections an adversarial review (codex) flagged."""
 
+import os
 import sys
 from pathlib import Path
 
@@ -168,3 +169,199 @@ def test_posix_absolute_and_colon_filenames(tmp_path):
     # ':' is a legal POSIX filename char — must NOT be rejected as ADS.
     assert _resolve_host_path("weird:name", tmp_path) == \
         (tmp_path / "weird:name").resolve()
+
+
+# --------------------------------------------------------------------------- #
+# link-safe resolver (#72, follow_leaf)
+# --------------------------------------------------------------------------- #
+
+def _symlink_or_skip(target: Path, link: Path):
+    try:
+        os.symlink(str(target), str(link),
+                   target_is_directory=target.is_dir())
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks not supported in this environment: {exc}")
+
+
+def test_follow_leaf_preserves_symlink_leaf(tmp_path):
+    target = tmp_path / "target_dir"
+    target.mkdir()
+    link = tmp_path / "link"
+    _symlink_or_skip(target, link)
+    # Default (follow_leaf=True) dereferences the leaf -> the real target.
+    assert _resolve_host_path("link", tmp_path) == target.resolve()
+    # Link-safe (follow_leaf=False) preserves the link entry itself.
+    safe = _resolve_host_path("link", tmp_path, follow_leaf=False)
+    assert os.path.islink(str(safe))
+    assert safe == (tmp_path.resolve() / "link")
+
+
+# --------------------------------------------------------------------------- #
+# /file/copy (#72)
+# --------------------------------------------------------------------------- #
+
+def test_copy_file_ok(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("hello", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/copy",
+                                json={"src": "a.txt", "dst": "b.txt"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert (tmp_path / "b.txt").read_text(encoding="utf-8") == "hello"
+    assert (tmp_path / "a.txt").exists()          # source untouched
+
+
+def test_copy_dir_ok(tmp_path, monkeypatch):
+    src = tmp_path / "tree"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "f.txt").write_text("x", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/copy",
+                                json={"src": "tree", "dst": "tree2"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert (tmp_path / "tree2" / "sub" / "f.txt").read_text(encoding="utf-8") == "x"
+
+
+def test_copy_exists_without_overwrite_409(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/copy",
+                                json={"src": "a.txt", "dst": "b.txt"})
+    assert r.status == 409 and r.json["error"] == "exists"
+    assert (tmp_path / "b.txt").read_text(encoding="utf-8") == "b"   # untouched
+
+
+def test_copy_overwrite_ok(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post(
+        "/file/copy", json={"src": "a.txt", "dst": "b.txt", "overwrite": True})
+    assert r.status == 200 and r.json["ok"] is True
+    assert (tmp_path / "b.txt").read_text(encoding="utf-8") == "a"
+
+
+def test_copy_dest_in_source_rejected_no_500(tmp_path, monkeypatch):
+    # Copying a dir into its own subtree would recurse forever — must be a clean
+    # 400, never a 500 / RecursionError + half-built litter.
+    (tmp_path / "tree").mkdir()
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/copy",
+                                json={"src": "tree", "dst": "tree/inner"})
+    assert r.status == 400 and r.json["error"] == "dest_in_source"
+
+
+def test_copy_same_rejected(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/copy",
+                                json={"src": "a.txt", "dst": "a.txt"})
+    assert r.status == 400 and r.json["error"] == "same"
+
+
+def test_copy_type_mismatch(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "d").mkdir()
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post(
+        "/file/copy", json={"src": "a.txt", "dst": "d", "overwrite": True})
+    assert r.status == 400 and r.json["error"] == "type_mismatch"
+
+
+def test_copy_source_missing_404(tmp_path, monkeypatch):
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/copy",
+                                json={"src": "nope", "dst": "x"})
+    assert r.status == 404 and r.json["error"] == "not_found"
+
+
+# --------------------------------------------------------------------------- #
+# /file/move (#72)
+# --------------------------------------------------------------------------- #
+
+def test_move_file_ok(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/move",
+                                json={"src": "a.txt", "dst": "b.txt"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not (tmp_path / "a.txt").exists()
+    assert (tmp_path / "b.txt").read_text(encoding="utf-8") == "hi"
+
+
+def test_move_dir_ok(tmp_path, monkeypatch):
+    src = tmp_path / "tree"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "f.txt").write_text("x", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/move",
+                                json={"src": "tree", "dst": "tree2"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not (tmp_path / "tree").exists()
+    assert (tmp_path / "tree2" / "sub" / "f.txt").read_text(encoding="utf-8") == "x"
+
+
+def test_move_exists_without_overwrite_409(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/move",
+                                json={"src": "a.txt", "dst": "b.txt"})
+    assert r.status == 409 and r.json["error"] == "exists"
+    assert (tmp_path / "a.txt").exists()          # source untouched
+
+
+def test_move_overwrite_file_ok(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post(
+        "/file/move", json={"src": "a.txt", "dst": "b.txt", "overwrite": True})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not (tmp_path / "a.txt").exists()
+    assert (tmp_path / "b.txt").read_text(encoding="utf-8") == "a"
+
+
+def test_move_overwrite_dir_ok(tmp_path, monkeypatch):
+    # The backup-and-restore path (no atomic dir-over-dir replace on Windows).
+    src = tmp_path / "tree"
+    src.mkdir()
+    (src / "f.txt").write_text("new", encoding="utf-8")
+    dst = tmp_path / "dest"
+    dst.mkdir()
+    (dst / "old.txt").write_text("old", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post(
+        "/file/move", json={"src": "tree", "dst": "dest", "overwrite": True})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not (tmp_path / "tree").exists()
+    assert (tmp_path / "dest" / "f.txt").read_text(encoding="utf-8") == "new"
+    assert not (tmp_path / "dest" / "old.txt").exists()   # replaced, not merged
+    # no stray backup left behind
+    assert not list(tmp_path.glob("dest.webterm-bak-*"))
+
+
+def test_move_source_missing_404(tmp_path, monkeypatch):
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/move",
+                                json={"src": "nope", "dst": "x"})
+    assert r.status == 404 and r.json["error"] == "not_found"
+
+
+def test_move_symlink_to_dir_moves_link_not_target(tmp_path, monkeypatch):
+    # The headline data-loss guard for move: relocating a symlink-to-dir moves
+    # the LINK entry; the target tree (and its contents) stays put.
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "keep.txt").write_text("precious", encoding="utf-8")
+    link = tmp_path / "link"
+    _symlink_or_skip(target, link)
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/move",
+                                json={"src": "link", "dst": "moved"})
+    assert r.status == 200 and r.json["ok"] is True
+    moved = tmp_path / "moved"
+    assert os.path.islink(str(moved))             # the link itself moved
+    assert not os.path.lexists(str(link))         # old link gone
+    assert target.is_dir()                        # target tree intact
+    assert (target / "keep.txt").read_text(encoding="utf-8") == "precious"

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -365,3 +365,71 @@ def test_move_symlink_to_dir_moves_link_not_target(tmp_path, monkeypatch):
     assert not os.path.lexists(str(link))         # old link gone
     assert target.is_dir()                        # target tree intact
     assert (target / "keep.txt").read_text(encoding="utf-8") == "precious"
+
+
+# --------------------------------------------------------------------------- #
+# /file/delete (#72 — recursive + reparse-safe)
+# --------------------------------------------------------------------------- #
+
+def test_delete_file_ok(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/delete", json={"path": "a.txt"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not (tmp_path / "a.txt").exists()
+
+
+def test_delete_dir_without_recursive_is_400(tmp_path, monkeypatch):
+    d = tmp_path / "d"
+    (d / "child.txt").parent.mkdir()
+    (d / "child.txt").write_text("x", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/delete", json={"path": "d"})
+    assert r.status == 400 and r.json["error"] == "is_a_directory"
+    assert d.is_dir()                             # untouched without recursive
+
+
+def test_delete_dir_recursive_ok(tmp_path, monkeypatch):
+    d = tmp_path / "d"
+    (d / "sub").mkdir(parents=True)
+    (d / "sub" / "f.txt").write_text("x", encoding="utf-8")
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/delete",
+                                json={"path": "d", "recursive": True})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not d.exists()
+
+
+def test_delete_missing_404(tmp_path, monkeypatch):
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/delete", json={"path": "nope"})
+    assert r.status == 404 and r.json["error"] == "not_found"
+
+
+def test_delete_symlink_to_dir_unlinks_link_keeps_target(tmp_path, monkeypatch):
+    # THE headline data-loss guard: deleting a symlink-to-dir (even recursive)
+    # removes only the link; the target tree and its files survive.
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "keep.txt").write_text("precious", encoding="utf-8")
+    link = tmp_path / "link"
+    _symlink_or_skip(target, link)
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/delete",
+                                json={"path": "link", "recursive": True})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not os.path.lexists(str(link))         # link gone
+    assert target.is_dir()                        # target intact
+    assert (target / "keep.txt").read_text(encoding="utf-8") == "precious"
+
+
+def test_delete_symlink_to_file_unlinks_link_keeps_target(tmp_path, monkeypatch):
+    target = tmp_path / "real.txt"
+    target.write_text("precious", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    _symlink_or_skip(target, link)
+    app = _make_file_app(tmp_path, monkeypatch)
+    _, r = app.test_client.post("/file/delete", json={"path": "link.txt"})
+    assert r.status == 200 and r.json["ok"] is True
+    assert not os.path.lexists(str(link))
+    assert target.read_text(encoding="utf-8") == "precious"

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -965,6 +965,34 @@ def test_file_capability_richer_ops_present():
         assert route in INDEX_HTML, f"#72 route missing from served page: {route!r}"
 
 
+def test_filemanager_richer_menu_present():
+    # #72: the file manager grows a full right-click menu set + clipboard + drag.
+    # These symbol sentinels lock the wiring (the Playwright flow exercises the
+    # behavior). The FM routes every confirm/prompt through the styled dialog
+    # component — NO native confirm()/prompt() survives in the mod.
+    fm = (BROKER_DIR / "mods" / "file-manager" / "file-manager.js").read_text(
+        encoding="utf-8")
+    for sym in ("const doTransfer", "const buildRowMenu", "const buildEmptyMenu",
+                "const setClipboard", "const pasteInto", "const validateName",
+                "const newFolder", "const renameRow", "const deleteRow",
+                "const downloadRow", "const zipRow", "const unzipRow",
+                "const showProperties", "const makeDraggable",
+                "win.fmClipboard"):
+        assert sym in fm, f"file manager missing #72 symbol: {sym!r}"
+    # Uses the styled dialog component, not native modals.
+    for sym in ("openConfirmDialog(", "openTextPrompt(", "openInfoModal("):
+        assert sym in fm, f"file manager should use styled dialog: {sym!r}"
+    import re
+    assert not re.search(r"(?<![A-Za-z])confirm\(", fm), \
+        "native confirm() must be gone from the file manager (use openConfirmDialog)"
+    assert not re.search(r"(?<![A-Za-z])prompt\(", fm), \
+        "native prompt() must be gone from the file manager (use openTextPrompt)"
+    # The drag payload now carries the entry type (cross-host dir refusal).
+    assert "type: ent.type" in fm
+    # And the menu wiring reaches the served page.
+    assert "buildRowMenu" in INDEX_HTML and "buildEmptyMenu" in INDEX_HTML
+
+
 def test_file_capability_trust_doc_present():
     # The trust-tier doc ships in-code WITH the capability: ctx.file is operator-
     # granted REVIEW HYGIENE, not enforcement (a same-origin mod can already POST

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -920,6 +920,27 @@ def test_file_capability_present():
         assert sym in INDEX_HTML, f"ctx.file missing from served page: {sym!r}"
 
 
+def test_dialog_component_present():
+    # #72 (Part A): the reusable styled dialog primitive + wrappers ship as the
+    # new 69_js_dialog.js fragment, registered right after the file-dialog
+    # fragment, and reach the served page; its CSS rides the shared dialogs
+    # fragment by folding .app-dialog into the existing selector groups.
+    assert "69_js_dialog.js" in ui._ORDERED
+    assert ui._ORDERED.index("69_js_dialog.js") == \
+        ui._ORDERED.index("68_js_app_windows_files.js") + 1
+    assert (BROKER_DIR / "69_js_dialog.js").is_file()
+    src = (BROKER_DIR / "69_js_dialog.js").read_text(encoding="utf-8")
+    for sym in ("function openDialog", "function openTextPrompt",
+                "function openConfirmDialog", "function openInfoModal"):
+        assert sym in src, f"dialog fragment missing {sym!r}"
+        assert sym in INDEX_HTML, f"dialog symbol missing from served page: {sym!r}"
+    css = (BROKER_DIR / "15_css_dialogs.css").read_text(encoding="utf-8")
+    for sel in (".app-dialog-overlay", ".app-dialog button.danger",
+                ".app-dialog-rows"):
+        assert sel in css, f"dialog CSS missing {sel!r}"
+    assert ".app-dialog" in INDEX_HTML
+
+
 def test_file_capability_richer_ops_present():
     # #72: ctx.file gains mkdir/copy/move/zip/unzip/stat and a recursive flag on
     # delete; ctxVersion stays 1 (additive). The SAME methods are mirrored in the

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -920,6 +920,30 @@ def test_file_capability_present():
         assert sym in INDEX_HTML, f"ctx.file missing from served page: {sym!r}"
 
 
+def test_file_capability_richer_ops_present():
+    # #72: ctx.file gains mkdir/copy/move/zip/unzip/stat and a recursive flag on
+    # delete; ctxVersion stays 1 (additive). The SAME methods are mirrored in the
+    # file-manager's fmFile() fallback so its I/O is identical mods on or off.
+    loader = (BROKER_DIR / "86_js_mod_loader.js").read_text(encoding="utf-8")
+    fm = (BROKER_DIR / "mods" / "file-manager" / "file-manager.js").read_text(
+        encoding="utf-8")
+    for src, label in ((loader, "loader ctx.file"), (fm, "fmFile fallback")):
+        for sym in ("mkdir: function", "copy: function", "move: function",
+                    "zip: function", "unzip: function", "stat: function"):
+            assert sym in src, f"{label} missing #72 method: {sym!r}"
+        for route in ("'/file/mkdir'", "'/file/copy'", "'/file/move'",
+                      "'/file/zip'", "'/file/unzip'", "'/file/stat'"):
+            assert route in src, f"{label} does not wrap route {route!r}"
+        # delete carries the recursive flag.
+        assert "recursive: !!(opts && opts.recursive)" in src, \
+            f"{label} delete missing recursive flag"
+    # ctxVersion unchanged (additive capability).
+    assert "ctxVersion: 1" in loader
+    # And the new routes reach the served page.
+    for route in ("'/file/copy'", "'/file/zip'", "'/file/stat'"):
+        assert route in INDEX_HTML, f"#72 route missing from served page: {route!r}"
+
+
 def test_file_capability_trust_doc_present():
     # The trust-tier doc ships in-code WITH the capability: ctx.file is operator-
     # granted REVIEW HYGIENE, not enforcement (a same-origin mod can already POST

--- a/webterm/broker/15_css_dialogs.css
+++ b/webterm/broker/15_css_dialogs.css
@@ -1,6 +1,7 @@
         /* Control Panel modal sits above windows (100000) but below #ctx-menu
            (200000); the re-auth overlay outranks everything. */
-        #settings-overlay, #auth-overlay, #become-active-overlay {
+        #settings-overlay, #auth-overlay, #become-active-overlay,
+        .app-dialog-overlay {
             position: fixed;
             inset: 0;
             background: rgba(0, 0, 0, 0.55);
@@ -10,11 +11,14 @@
         }
         #settings-overlay { z-index: 150000; }
         #auth-overlay { z-index: 250000; }
+        /* #72 (Part A): the reusable styled dialog sits above the file dialog
+           (180000) but below #ctx-menu (200000) / #auth-overlay (250000). */
+        .app-dialog-overlay { z-index: 185000; }
         /* The deactivated full-page takeover prompt sits just below the auth
            overlay so a password prompt still wins. */
         #become-active-overlay { z-index: 240000; background: rgba(0,0,0,0.82); }
         #settings-overlay.open, #auth-overlay.open,
-        #become-active-overlay.open { display: flex; }
+        #become-active-overlay.open, .app-dialog-overlay.open { display: flex; }
         #become-active-box {
             background: var(--bg-2);
             border: 1px solid #000;
@@ -38,7 +42,7 @@
             padding: 8px 20px;
             cursor: pointer;
         }
-        #settings-modal, #auth-form {
+        #settings-modal, #auth-form, .app-dialog {
             background: var(--bg-2);
             border: 1px solid #000;
             border-left: 4px solid var(--accent-default);
@@ -110,7 +114,8 @@
         #settings-modal input[type=number],
         #settings-modal input[type=text],
         #settings-modal input[type=password],
-        #auth-form input[type=password] {
+        #auth-form input[type=password],
+        .app-dialog input[type=text] {
             background: var(--bg);
             border: 1px solid var(--bg-3);
             border-radius: 3px;
@@ -121,11 +126,12 @@
             outline: none;
         }
         #settings-modal input:focus,
-        #auth-form input:focus { border-color: var(--accent-default); }
+        #auth-form input:focus,
+        .app-dialog input:focus { border-color: var(--accent-default); }
         #settings-modal input[type=number] { width: 64px; }
         #settings-modal input[type=text],
         #settings-modal input[type=password] { flex: 1 1 auto; min-width: 0; }
-        #settings-modal button, #auth-form button {
+        #settings-modal button, #auth-form button, .app-dialog button {
             background: var(--bg);
             border: 1px solid var(--bg-3);
             border-radius: 3px;
@@ -137,8 +143,27 @@
             flex: 0 0 auto;
         }
         #settings-modal button:hover,
-        #auth-form button:hover { background: #262626; border-color: #6a8; }
+        #auth-form button:hover,
+        .app-dialog button:hover { background: #262626; border-color: #6a8; }
         .set-foot { display: flex; justify-content: flex-end; }
+        /* #72 (Part A): dialog-specific bits; box/input/button styling is
+           inherited from the shared #settings-modal groups above. */
+        .app-dialog .set-foot { gap: 8px; }
+        .app-dialog button.primary { border-color: var(--accent-default); }
+        .app-dialog button.danger { color: #e96d6d; border-color: #e96d6d; }
+        .app-dialog button.danger:hover {
+            background: #3a2020; border-color: #e96d6d;
+        }
+        .app-dialog-field label { color: var(--fg-dim); flex: 0 0 auto; }
+        .app-dialog-msg { white-space: pre-wrap; line-height: 1.4; }
+        .app-dialog-rows { display: flex; flex-direction: column; gap: 4px; }
+        .app-dialog-row {
+            display: flex; gap: 10px; font-family: monospace; font-size: 12px;
+        }
+        .app-dialog-row .app-dialog-k { color: var(--fg-dim); flex: 0 0 38%; }
+        .app-dialog-row .app-dialog-v {
+            flex: 1 1 auto; min-width: 0; word-break: break-all;
+        }
         /* Tabbed settings (tasks 13/14): a flex row of small tab buttons, the
            active one highlighted with the accent. Wraps when many hosts. */
         .set-tabs {

--- a/webterm/broker/69_js_dialog.js
+++ b/webterm/broker/69_js_dialog.js
@@ -1,0 +1,222 @@
+        // ---- reusable styled dialog (#72, Part A) -------------------------
+        // One in-app modal primitive + thin wrappers, all hoisted globals so
+        // core AND mods can call them (the same posture as openFileDialog, which
+        // this mirrors). Built DYNAMICALLY: openDialog creates an
+        // `.app-dialog-overlay > .app-dialog`, appends it to <body>, and removes
+        // it on finish — no static markup. A module-level singleton guard
+        // (_dlgFinish) cancels any live dialog before opening a new one, so a
+        // second call can't orphan the first promise + its capture-phase Escape
+        // listener. The styling reuses the shared dialog CSS groups
+        // (15_css_dialogs.css), so these match the Control Panel / file dialog
+        // look. z-index 185000 sits above #file-overlay (180000) and below
+        // #ctx-menu (200000) / #auth-overlay (250000).
+        //
+        // openDialog(spec) -> Promise<{value,fields}|null>
+        //   spec = { title, body?(container), fields?:[{key,label,value,
+        //            placeholder,validate}], buttons?:[{label,value,primary,
+        //            danger}], initialFocus }
+        //   Resolves to {value:<clicked button.value>, fields:{<key>:<string>}}
+        //   on a button click, or null on Escape / backdrop click. Primary-button
+        //   commits run every field's validate(value) first: a truthy return is
+        //   shown as the error and the dialog stays open.
+        let _dlgFinish = null;
+        function openDialog(spec) {
+            if (_dlgFinish) _dlgFinish(null);   // cancel any live dialog first
+            spec = spec || {};
+            const overlay = document.createElement('div');
+            overlay.className = 'app-dialog-overlay';
+            const modal = document.createElement('div');
+            modal.className = 'app-dialog';
+            overlay.appendChild(modal);
+
+            if (spec.title) {
+                const head = document.createElement('div');
+                head.className = 'set-head';
+                head.textContent = spec.title;
+                modal.appendChild(head);
+            }
+            // Optional caller-built body (Properties rows, confirm message, …).
+            if (typeof spec.body === 'function') {
+                const bodyWrap = document.createElement('div');
+                bodyWrap.className = 'app-dialog-body';
+                try { spec.body(bodyWrap); } catch (_) {}
+                modal.appendChild(bodyWrap);
+            }
+            // Text fields (Rename / New folder / Zip name).
+            const fieldInputs = [];
+            if (Array.isArray(spec.fields)) {
+                for (const f of spec.fields) {
+                    const row = document.createElement('div');
+                    row.className = 'set-row app-dialog-field';
+                    if (f.label) {
+                        const lab = document.createElement('label');
+                        lab.textContent = f.label;
+                        row.appendChild(lab);
+                    }
+                    const input = document.createElement('input');
+                    input.type = 'text';
+                    input.value = (f.value != null) ? String(f.value) : '';
+                    if (f.placeholder) input.placeholder = f.placeholder;
+                    row.appendChild(input);
+                    modal.appendChild(row);
+                    fieldInputs.push({ key: f.key, input: input,
+                                       validate: f.validate });
+                }
+            }
+            const errEl = document.createElement('div');
+            errEl.className = 'set-err';
+            modal.appendChild(errEl);
+
+            const buttons = (Array.isArray(spec.buttons) && spec.buttons.length)
+                ? spec.buttons
+                : [{ label: 'OK', value: true, primary: true }];
+            const foot = document.createElement('div');
+            foot.className = 'set-foot app-dialog-foot';
+            modal.appendChild(foot);
+
+            return new Promise(function (resolve) {
+                let primarySpec = null;
+                const showErr = function (m) {
+                    errEl.textContent = m; errEl.classList.add('show');
+                };
+                const collectFields = function (validate) {
+                    const out = {};
+                    for (const fi of fieldInputs) {
+                        const val = fi.input.value;
+                        if (validate && typeof fi.validate === 'function') {
+                            const msg = fi.validate(val);
+                            if (msg) { showErr(msg); fi.input.focus(); return null; }
+                        }
+                        out[fi.key] = val;
+                    }
+                    return out;
+                };
+                const finish = function (val) {
+                    if (_dlgFinish === finish) _dlgFinish = null;
+                    document.removeEventListener('keydown', onKey, true);
+                    if (overlay.parentNode) {
+                        overlay.parentNode.removeChild(overlay);
+                    }
+                    resolve(val);
+                };
+                _dlgFinish = finish;
+                const choose = function (btn) {
+                    // Validate only on a primary commit; a cancel/secondary
+                    // button never blocks on a bad field.
+                    const fields = collectFields(!!btn.primary);
+                    if (fields === null) return;        // validation failed
+                    finish({ value: btn.value, fields: fields });
+                };
+                for (const btn of buttons) {
+                    const b = document.createElement('button');
+                    b.type = 'button';
+                    b.textContent = btn.label || 'OK';
+                    if (btn.primary) b.classList.add('primary');
+                    if (btn.danger) b.classList.add('danger');
+                    b.addEventListener('click', function (e) {
+                        e.stopPropagation(); choose(btn);
+                    });
+                    foot.appendChild(b);
+                    if (btn.primary && !primarySpec) primarySpec = btn;
+                }
+                const onKey = function (e) {
+                    if (e.key === 'Escape') {
+                        e.preventDefault(); e.stopPropagation(); finish(null);
+                    } else if (e.key === 'Enter') {
+                        // Enter commits the primary action (not from a button,
+                        // which has its own click). Skip inside a textarea.
+                        const t = e.target;
+                        if (t && t.tagName === 'TEXTAREA') return;
+                        if (primarySpec) { e.preventDefault(); choose(primarySpec); }
+                    }
+                };
+                // Backdrop click (outside the modal) cancels; a mousedown inside
+                // the modal is swallowed so it never reaches the desktop beneath.
+                overlay.addEventListener('mousedown', function (e) {
+                    if (e.target === overlay) finish(null);
+                });
+                modal.addEventListener('mousedown', function (e) {
+                    e.stopPropagation();
+                });
+                document.addEventListener('keydown', onKey, true);
+                document.body.appendChild(overlay);
+                overlay.classList.add('open');
+                // Focus: first field (text selected for easy replace), else the
+                // primary button.
+                if (fieldInputs.length) {
+                    try { fieldInputs[0].input.focus();
+                          fieldInputs[0].input.select(); } catch (_) {}
+                } else {
+                    const pb = foot.querySelector('button.primary')
+                        || foot.querySelector('button');
+                    if (pb) { try { pb.focus(); } catch (_) {} }
+                }
+            });
+        }
+
+        // Single text field -> the typed string, or null on cancel/Escape.
+        function openTextPrompt(opts) {
+            opts = opts || {};
+            return openDialog({
+                title: opts.title || 'Enter a value',
+                fields: [{
+                    key: 'text',
+                    label: opts.label || '',
+                    value: opts.value || '',
+                    placeholder: opts.placeholder || '',
+                    validate: opts.validate,
+                }],
+                buttons: [
+                    { label: opts.okLabel || 'OK', value: true, primary: true },
+                    { label: 'Cancel', value: false },
+                ],
+            }).then(function (r) {
+                return (r && r.value) ? r.fields.text : null;
+            });
+        }
+
+        // Confirm box -> true on OK, false on Cancel/Escape/backdrop.
+        function openConfirmDialog(opts) {
+            opts = opts || {};
+            return openDialog({
+                title: opts.title || 'Confirm',
+                body: function (c) {
+                    const p = document.createElement('div');
+                    p.className = 'app-dialog-msg';
+                    p.textContent = opts.message || '';
+                    c.appendChild(p);
+                },
+                buttons: [
+                    { label: opts.okLabel || 'OK', value: true, primary: true,
+                      danger: !!opts.danger },
+                    { label: 'Cancel', value: false },
+                ],
+            }).then(function (r) { return !!(r && r.value); });
+        }
+
+        // Read-only info modal (Properties): a list of {k,v} rows + a Close.
+        function openInfoModal(opts) {
+            opts = opts || {};
+            return openDialog({
+                title: opts.title || 'Properties',
+                body: function (c) {
+                    const tbl = document.createElement('div');
+                    tbl.className = 'app-dialog-rows';
+                    for (const row of (opts.rows || [])) {
+                        const r = document.createElement('div');
+                        r.className = 'app-dialog-row';
+                        const k = document.createElement('span');
+                        k.className = 'app-dialog-k';
+                        k.textContent = (row.k != null) ? String(row.k) : '';
+                        const v = document.createElement('span');
+                        v.className = 'app-dialog-v';
+                        v.textContent = (row.v != null) ? String(row.v) : '';
+                        r.appendChild(k);
+                        r.appendChild(v);
+                        tbl.appendChild(r);
+                    }
+                    c.appendChild(tbl);
+                },
+                buttons: [{ label: 'Close', value: true, primary: true }],
+            }).then(function () {});
+        }

--- a/webterm/broker/86_js_mod_loader.js
+++ b/webterm/broker/86_js_mod_loader.js
@@ -150,11 +150,14 @@
                     list: function (path, opts) {
                         return _modFileApi('/file/list', { path: path || '' }, opts);
                     },
-                    // Single-file delete (refuses a directory). -> {ok,path}.
-                    // Quoted key so the reserved word can never trip a minifier;
+                    // Delete a file, a symlink/junction (entry only), or — with
+                    // opts.recursive — a directory tree. -> {ok,path}. Quoted key
+                    // so the reserved word can never trip a minifier;
                     // ctx.file.delete(...) still calls it.
                     'delete': function (path, opts) {
-                        return _modFileApi('/file/delete', { path: path }, opts);
+                        return _modFileApi('/file/delete',
+                            { path: path,
+                              recursive: !!(opts && opts.recursive) }, opts);
                     },
                     // Binary-safe write via base64; opts.overwrite (default false)
                     // -> {ok,path,size} (or {ok:false,error:'exists'} on a clash).
@@ -162,6 +165,39 @@
                         return _modFileApi('/file/upload',
                             { path: path, content_b64: contentB64,
                               overwrite: !!(opts && opts.overwrite) }, opts);
+                    },
+                    // #72 richer ops (additive — ctxVersion stays 1). Paths are
+                    // host-wide native absolutes, same per-host routing.
+                    // Create ONE directory (parent must exist). -> {ok,path}.
+                    mkdir: function (path, opts) {
+                        return _modFileApi('/file/mkdir', { path: path }, opts);
+                    },
+                    // Server-side copy of a file or tree; opts.overwrite. ->{ok,path}
+                    copy: function (src, dst, opts) {
+                        return _modFileApi('/file/copy',
+                            { src: src, dst: dst,
+                              overwrite: !!(opts && opts.overwrite) }, opts);
+                    },
+                    // Server-side move/rename of a file or tree; opts.overwrite.
+                    move: function (src, dst, opts) {
+                        return _modFileApi('/file/move',
+                            { src: src, dst: dst,
+                              overwrite: !!(opts && opts.overwrite) }, opts);
+                    },
+                    // Zip a file/tree into dest archive; opts.overwrite. ->{ok,path}
+                    zip: function (src, dest, opts) {
+                        return _modFileApi('/file/zip',
+                            { src: src, dest: dest,
+                              overwrite: !!(opts && opts.overwrite) }, opts);
+                    },
+                    // Extract a .zip into a FRESH dest dir. -> {ok,path}.
+                    unzip: function (path, dest, opts) {
+                        return _modFileApi('/file/unzip',
+                            { path: path, dest: dest }, opts);
+                    },
+                    // Properties: type/size/mtime/mode (+children for a dir).
+                    stat: function (path, opts) {
+                        return _modFileApi('/file/stat', { path: path }, opts);
                     },
                 },
                 // #85 (S12): host session RPC — ONE reviewed wrapper over the

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -1499,6 +1499,44 @@ def create_app(config: Optional[Dict[str, Any]] = None,
             return sanic_json({"ok": False, "error": str(exc)}, status=400)
         return sanic_json({"ok": True, "path": dest_str})
 
+    async def _file_stat(request: Request):
+        # Properties (#72): type/size/mtime/mode for one path, plus a shallow
+        # child count for a directory. Read-only and chosen over extending
+        # /file/list (which only describes a dir's CHILDREN and is the hot path
+        # behind openFileDialog/renderPane). mtime is epoch seconds; mode is the
+        # raw st_mode int (the UI formats both).
+        err = _file_auth_error(request)
+        if err is not None:
+            return err
+        body = _json_object_body(request)
+        if body is None:
+            return sanic_json({"ok": False, "error": "bad_json"}, status=400)
+        rel = body.get("path")
+        if not isinstance(rel, str) or not rel:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        try:
+            p = _resolve_host_path(rel, app.ctx.editor_root)
+        except ValueError:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        kind = _classify_path(p)
+        if kind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if kind == "missing":
+            return sanic_json({"ok": False, "error": "not_found"}, status=404)
+        try:
+            st = p.stat()
+        except OSError as exc:
+            return sanic_json({"ok": False, "error": str(exc)}, status=400)
+        out = {"ok": True, "path": str(p), "type": kind,
+               "size": st.st_size, "mtime": st.st_mtime, "mode": st.st_mode}
+        if kind == "dir":
+            try:
+                out["children"] = sum(1 for _ in p.iterdir())
+            except OSError:
+                pass                               # unreadable dir — omit count
+        return sanic_json(out)
+
     # ---- task manager + git button (/session/*) --------------------------
     # On-demand broker<->producer round-trips (correlated by req id) so process
     # listing, scoped kill, and git status work for LOCAL and REMOTE sessions
@@ -2081,6 +2119,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
     app.add_route(_file_move, "/file/move", methods=["POST"])
     app.add_route(_file_zip, "/file/zip", methods=["POST"])
     app.add_route(_file_unzip, "/file/unzip", methods=["POST"])
+    app.add_route(_file_stat, "/file/stat", methods=["POST"])
     app.add_route(_session_procs, "/session/procs", methods=["POST"])
     app.add_route(_session_kill, "/session/kill", methods=["POST"])
     app.add_route(_session_git, "/session/git", methods=["POST"])
@@ -2114,6 +2153,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                              ("/file/move", "preflight_file_move"),
                              ("/file/zip", "preflight_file_zip"),
                              ("/file/unzip", "preflight_file_unzip"),
+                             ("/file/stat", "preflight_file_stat"),
                              ("/session/procs", "preflight_session_procs"),
                              ("/session/kill", "preflight_session_kill"),
                              ("/session/git", "preflight_session_git"),

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -1311,6 +1311,194 @@ def create_app(config: Optional[Dict[str, Any]] = None,
             return sanic_json({"ok": False, "error": str(exc)}, status=400)
         return sanic_json({"ok": True, "path": dst_str})
 
+    async def _file_zip(request: Request):
+        # Create a .zip from a file or directory tree. dest is the output archive
+        # path (its parent must be a dir). A pre-scan rejects a source that
+        # exceeds the caps BEFORE writing; the archive is built into a tempfile
+        # in dest's parent and os.replace'd into place, so dest is never left
+        # partial and an overwrite keeps the old archive until the new one is
+        # complete. Reparse-point subdirectories (symlinks AND junctions) are NOT
+        # followed (filtered out of the walk, so they're omitted); symlinked
+        # FILES are archived as their target content (zf.write follows them, and
+        # the pre-scan counts the same target size via getsize). The caps are
+        # pre-scan advisory — single-user, the source is the caller's own tree.
+        err = _file_auth_error(request)
+        if err is not None:
+            return err
+        body = _json_object_body(request)
+        if body is None:
+            return sanic_json({"ok": False, "error": "bad_json"}, status=400)
+        overwrite = bool(body.get("overwrite", False))
+        src_rel = body.get("src")
+        dest_rel = body.get("dest")
+        if not isinstance(src_rel, str) or not src_rel:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        if not isinstance(dest_rel, str) or not dest_rel:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        try:
+            src = _resolve_host_path(src_rel, app.ctx.editor_root)
+            dest = _resolve_host_path(dest_rel, app.ctx.editor_root)
+        except ValueError:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        src_kind = _classify_path(src)
+        if src_kind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if src_kind == "missing":
+            return sanic_json({"ok": False, "error": "not_found"}, status=404)
+        if src_kind not in ("file", "dir"):
+            return sanic_json({"ok": False, "error": "not_supported"},
+                              status=400)
+        dest_kind = _classify_path(dest)
+        if dest_kind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if dest_kind == "dir":
+            return sanic_json({"ok": False, "error": "not_a_file"}, status=400)
+        if dest_kind != "missing" and not overwrite:
+            return sanic_json({"ok": False, "error": "exists"}, status=409)
+        dparent = _classify_path(dest.parent)
+        if dparent == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if dparent != "dir":
+            return sanic_json({"ok": False, "error": "parent_missing"},
+                              status=400)
+        if src_kind == "dir" and _is_within(dest, src):
+            # The growing archive must not live inside the tree being zipped.
+            return sanic_json({"ok": False, "error": "dest_in_source"},
+                              status=400)
+        src_str, dest_str = str(src), str(dest)
+
+        def _do_zip():
+            total = 0
+            count = 0
+            if src_kind == "file":
+                total = os.path.getsize(src_str)
+                count = 1
+            else:
+                for root, dirs, files in os.walk(src_str):
+                    dirs[:] = [d for d in dirs
+                               if not _is_reparse_point(os.path.join(root, d))]
+                    count += 1 + len(files)        # this dir entry + its files
+                    if count > MAX_ARCHIVE_ENTRIES:
+                        raise ValueError("too_many_entries")
+                    for name in files:
+                        try:
+                            total += os.path.getsize(os.path.join(root, name))
+                        except OSError:
+                            pass
+                    if total > MAX_ARCHIVE_BYTES:
+                        raise ValueError("archive_too_large")
+            parent = os.path.dirname(dest_str) or "."
+            fd, tmp = tempfile.mkstemp(dir=parent, prefix=".webterm-zip-",
+                                       suffix=".tmp")
+            os.close(fd)
+            try:
+                with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zf:
+                    if src_kind == "file":
+                        zf.write(src_str, arcname=os.path.basename(src_str))
+                    else:
+                        # arcnames relative to src's PARENT so the archive holds
+                        # the top folder; write each walked dir (preserves empty
+                        # dirs) then each file.
+                        base = os.path.dirname(src_str)
+                        for root, dirs, files in os.walk(src_str):
+                            dirs[:] = [d for d in dirs
+                                       if not _is_reparse_point(
+                                           os.path.join(root, d))]
+                            zf.write(root, arcname=os.path.relpath(root, base))
+                            for name in files:
+                                fp = os.path.join(root, name)
+                                zf.write(fp, arcname=os.path.relpath(fp, base))
+                os.replace(tmp, dest_str)
+                tmp = None
+            finally:
+                if tmp is not None:
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+
+        try:
+            await asyncio.get_running_loop().run_in_executor(None, _do_zip)
+        except (OSError, ValueError, shutil.Error, RecursionError,
+                zipfile.BadZipFile) as exc:
+            return sanic_json({"ok": False, "error": str(exc)}, status=400)
+        return sanic_json({"ok": True, "path": dest_str})
+
+    async def _file_unzip(request: Request):
+        # Extract a .zip into a FRESH dest directory (dest must not exist). A
+        # zip-bomb / oversize guard rejects an archive whose entry count or
+        # cumulative declared uncompressed size exceeds the caps BEFORE any
+        # extraction. CPython's extractall already neutralises path traversal
+        # (absolute / drive-letter / '..' members are sanitised to land UNDER
+        # dest), so there is deliberately no hand-rolled commonpath loop; a
+        # malformed member fails extraction cleanly and the freshly-created dest
+        # is removed. The size guard trusts the central-directory sizes
+        # (single-user threat model).
+        err = _file_auth_error(request)
+        if err is not None:
+            return err
+        body = _json_object_body(request)
+        if body is None:
+            return sanic_json({"ok": False, "error": "bad_json"}, status=400)
+        path_rel = body.get("path")
+        dest_rel = body.get("dest")
+        if not isinstance(path_rel, str) or not path_rel:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        if not isinstance(dest_rel, str) or not dest_rel:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        try:
+            zpath = _resolve_host_path(path_rel, app.ctx.editor_root)
+            dest = _resolve_host_path(dest_rel, app.ctx.editor_root)
+        except ValueError:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        zkind = _classify_path(zpath)
+        if zkind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if zkind == "missing":
+            return sanic_json({"ok": False, "error": "not_found"}, status=404)
+        if zkind != "file":
+            return sanic_json({"ok": False, "error": "not_a_file"}, status=400)
+        dest_kind = _classify_path(dest)
+        if dest_kind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if dest_kind != "missing":
+            return sanic_json({"ok": False, "error": "exists"}, status=409)
+        dparent = _classify_path(dest.parent)
+        if dparent == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if dparent != "dir":
+            return sanic_json({"ok": False, "error": "parent_missing"},
+                              status=400)
+        zpath_str, dest_str = str(zpath), str(dest)
+
+        def _do_unzip():
+            with zipfile.ZipFile(zpath_str) as zf:
+                infos = zf.infolist()
+                if len(infos) > MAX_ARCHIVE_ENTRIES:
+                    raise ValueError("too_many_entries")
+                if sum(zi.file_size for zi in infos) > MAX_ARCHIVE_BYTES:
+                    raise ValueError("archive_too_large")
+                os.mkdir(dest_str)
+                try:
+                    zf.extractall(dest_str)
+                except BaseException:
+                    shutil.rmtree(dest_str, ignore_errors=True)
+                    raise
+
+        try:
+            await asyncio.get_running_loop().run_in_executor(None, _do_unzip)
+        except zipfile.BadZipFile:
+            return sanic_json({"ok": False, "error": "bad_zip"}, status=400)
+        except (OSError, ValueError, shutil.Error, RecursionError) as exc:
+            return sanic_json({"ok": False, "error": str(exc)}, status=400)
+        return sanic_json({"ok": True, "path": dest_str})
+
     # ---- task manager + git button (/session/*) --------------------------
     # On-demand broker<->producer round-trips (correlated by req id) so process
     # listing, scoped kill, and git status work for LOCAL and REMOTE sessions
@@ -1891,6 +2079,8 @@ def create_app(config: Optional[Dict[str, Any]] = None,
     app.add_route(_file_mkdir, "/file/mkdir", methods=["POST"])
     app.add_route(_file_copy, "/file/copy", methods=["POST"])
     app.add_route(_file_move, "/file/move", methods=["POST"])
+    app.add_route(_file_zip, "/file/zip", methods=["POST"])
+    app.add_route(_file_unzip, "/file/unzip", methods=["POST"])
     app.add_route(_session_procs, "/session/procs", methods=["POST"])
     app.add_route(_session_kill, "/session/kill", methods=["POST"])
     app.add_route(_session_git, "/session/git", methods=["POST"])
@@ -1922,6 +2112,8 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                              ("/file/mkdir", "preflight_file_mkdir"),
                              ("/file/copy", "preflight_file_copy"),
                              ("/file/move", "preflight_file_move"),
+                             ("/file/zip", "preflight_file_zip"),
+                             ("/file/unzip", "preflight_file_unzip"),
                              ("/session/procs", "preflight_session_procs"),
                              ("/session/kill", "preflight_session_kill"),
                              ("/session/git", "preflight_session_git"),

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -38,12 +38,14 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import errno
 import json
 import logging
 import os
 import re
 import secrets
 import shutil
+import stat
 import tempfile
 import uuid
 import zipfile
@@ -223,7 +225,8 @@ def _load_or_create_broker_id(path: Path) -> str:
     return bid
 
 
-def _resolve_host_path(rel: str, default_dir: Path) -> Path:
+def _resolve_host_path(rel: str, default_dir: Path,
+                       follow_leaf: bool = True) -> Path:
     """Resolve a client-supplied file path **host-wide** — anywhere on this box,
     with NO ``editor_root`` confinement (#35).
 
@@ -249,7 +252,17 @@ def _resolve_host_path(rel: str, default_dir: Path) -> Path:
     dir is the POINT here, not a bypass to defend against). A colon in any
     non-anchor component (``file:ads``, ``dir:x\\f``) is an NTFS
     alternate-data-stream spelling and is rejected. Resolver failures (symlink
-    loop, bad drive) raise ``ValueError`` -> the caller maps to ``bad_path``."""
+    loop, bad drive) raise ``ValueError`` -> the caller maps to ``bad_path``.
+
+    ``follow_leaf`` (#72, default ``True``) keeps the full ``resolve()`` — i.e.
+    every existing caller is byte-identical. With ``follow_leaf=False`` the
+    PARENT is resolved (symlinks higher in the path still collapse) and the raw
+    leaf name is re-attached, so a symlink or junction AT the leaf is *preserved*
+    for the caller to handle rather than dereferenced. This is load-bearing for
+    the destructive ops: a naive ``rmtree``/``rename``/``move`` of a fully
+    resolved symlink-to-dir would operate on the link's TARGET tree (host-wide
+    data loss); link-safe resolution hands the caller the link itself. The ADS
+    and half-absolute rejections apply identically in both modes."""
     raw = rel or ""
     base = Path(raw)
     # ADS guard (Windows only — ':' is a legal filename char on POSIX): drop the
@@ -266,9 +279,106 @@ def _resolve_host_path(rel: str, default_dir: Path) -> Path:
     else:
         p = default_dir / base
     try:
-        return p.resolve()
+        if follow_leaf:
+            return p.resolve()
+        # Link-safe leaf: resolve the parent, re-attach the raw leaf name. A path
+        # that is its own anchor (no leaf name, e.g. ``C:\``) has nothing to
+        # preserve, so fall back to a full resolve.
+        name = p.name
+        if not name:
+            return p.resolve()
+        return p.parent.resolve() / name
     except (OSError, RuntimeError, ValueError) as exc:
         raise ValueError("bad_path") from exc
+
+
+def _is_reparse_point(path_str: str) -> bool:
+    """True if the leaf at ``path_str`` is a symlink OR (Windows) a junction /
+    other reparse point. ``os.path.islink`` alone misses junctions on Python
+    < 3.12, so the reparse-point attribute bit is checked too — a destructive op
+    must treat a junction-to-dir like a link (remove the entry, never recurse
+    into its target). Best-effort: any stat failure returns False and the
+    caller's normal classification handles it."""
+    try:
+        if os.path.islink(path_str):
+            return True
+    except OSError:
+        return False
+    if os.name == "nt":
+        try:
+            attrs = os.lstat(path_str).st_file_attributes
+        except (OSError, AttributeError):
+            return False
+        return bool(attrs & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    return False
+
+
+def _remove_link(path_str: str) -> None:
+    """Remove a symlink / junction ENTRY without touching its target. A
+    directory-type link (dir symlink or junction) needs ``os.rmdir`` on Windows
+    — ``os.unlink`` raises on it — while a file symlink (and a broken link) need
+    ``os.unlink``. ``os.path.isdir`` follows the link to choose; a broken link
+    (isdir False) takes the unlink path."""
+    if os.path.isdir(path_str):
+        os.rmdir(path_str)
+    else:
+        os.unlink(path_str)
+
+
+def _force_remove(path_str: str) -> None:
+    """Remove any leaf — a symlink/junction (entry only, never the target), a
+    real file, or a real directory tree. Used by move-overwrite and recursive
+    delete. The reparse-point check comes first so a link is never dereferenced
+    into an rmtree of its target."""
+    if _is_reparse_point(path_str):
+        _remove_link(path_str)
+    elif os.path.isdir(path_str):
+        shutil.rmtree(path_str)
+    else:
+        os.unlink(path_str)
+
+
+def _rename_or_move(src_str: str, dst_str: str) -> None:
+    """Move ``src`` onto a NON-EXISTENT ``dst``: ``os.replace`` (atomic on one
+    volume; moves a symlink/junction as the entry, not the target), falling back
+    to ``shutil.move`` only on a cross-device error (EXDEV)."""
+    try:
+        os.replace(src_str, dst_str)
+    except OSError as exc:
+        if getattr(exc, "errno", None) == errno.EXDEV:
+            shutil.move(src_str, dst_str)
+        else:
+            raise
+
+
+def _resolve_two(body: Dict[str, Any], default_dir: Path,
+                 src_follow_leaf: bool = True,
+                 dst_follow_leaf: bool = True):
+    """Resolve the ``src`` and ``dst`` string fields of a copy/move body
+    host-wide. Returns ``(src, dst)`` Paths, or raises ``ValueError`` (mapped to
+    ``bad_path`` by the caller) on a missing / non-string field or a resolver
+    failure. ``*_follow_leaf`` pick link-safe leaf resolution per side: move
+    resolves both link-safe (so it relocates a link entry, not its target); copy
+    follows (it is non-destructive to the source)."""
+    src_rel = body.get("src")
+    dst_rel = body.get("dst")
+    if not isinstance(src_rel, str) or not src_rel:
+        raise ValueError("bad_path")
+    if not isinstance(dst_rel, str) or not dst_rel:
+        raise ValueError("bad_path")
+    src = _resolve_host_path(src_rel, default_dir, follow_leaf=src_follow_leaf)
+    dst = _resolve_host_path(dst_rel, default_dir, follow_leaf=dst_follow_leaf)
+    return src, dst
+
+
+def _is_within(child: Path, ancestor: Path) -> bool:
+    """True if ``child`` is ``ancestor`` or lives under it (case-insensitive on
+    Windows via the pure-path compare). Refuses copying/moving a tree into
+    itself — which would recurse infinitely and litter a partial copy."""
+    try:
+        return child.is_relative_to(ancestor)
+    except (ValueError, TypeError):
+        return False
 
 
 def _classify_path(p: Path) -> str:
@@ -1020,6 +1130,161 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         return sanic_json({"ok": True,
                            "path": str(p)})      # absolute, host-wide (#35)
 
+    async def _file_copy(request: Request):
+        # Copy a file or directory tree. src is followed (copy is non-destructive
+        # to the source); dst is the FULL target path (not a container). A dir
+        # uses copytree(symlinks=True) so INNER links are copied as links, not
+        # materialised; a file uses copy2 (metadata preserved). Refuses src==dst
+        # and dst-inside-src (the latter would recurse / litter — P0-2).
+        #
+        # NOTE: an overwrite is NOT atomic — copy2 / copytree(dirs_exist_ok=True)
+        # write over the destination in place, so a mid-copy failure can leave a
+        # damaged dst the caller asked to replace. Partial-dst cleanup therefore
+        # runs only when !overwrite (where dst was freshly created and is ours to
+        # remove); an overwrite failure is reported, not rolled back.
+        err = _file_auth_error(request)
+        if err is not None:
+            return err
+        body = _json_object_body(request)
+        if body is None:
+            return sanic_json({"ok": False, "error": "bad_json"}, status=400)
+        overwrite = bool(body.get("overwrite", False))
+        try:
+            src, dst = _resolve_two(body, app.ctx.editor_root)
+        except ValueError:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        if src == dst:
+            return sanic_json({"ok": False, "error": "same"}, status=400)
+        if _is_within(dst, src):
+            return sanic_json({"ok": False, "error": "dest_in_source"},
+                              status=400)
+        src_kind = _classify_path(src)
+        if src_kind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if src_kind == "missing":
+            return sanic_json({"ok": False, "error": "not_found"}, status=404)
+        if src_kind not in ("file", "dir"):
+            return sanic_json({"ok": False, "error": "not_supported"},
+                              status=400)
+        dst_kind = _classify_path(dst)
+        if dst_kind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        dparent = _classify_path(dst.parent)
+        if dparent == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if dparent != "dir":
+            return sanic_json({"ok": False, "error": "parent_missing"},
+                              status=400)
+        if dst_kind != "missing":
+            if not overwrite:
+                return sanic_json({"ok": False, "error": "exists"}, status=409)
+            if dst_kind != src_kind:
+                return sanic_json({"ok": False, "error": "type_mismatch"},
+                                  status=400)
+        src_str, dst_str = str(src), str(dst)
+
+        def _do_copy():
+            if src_kind == "dir":
+                shutil.copytree(src_str, dst_str, symlinks=True,
+                                dirs_exist_ok=overwrite)
+            else:
+                shutil.copy2(src_str, dst_str)
+
+        try:
+            await asyncio.get_running_loop().run_in_executor(None, _do_copy)
+        except (OSError, ValueError, shutil.Error, RecursionError) as exc:
+            if not overwrite:
+                # dst was freshly created by this op — remove the partial litter.
+                try:
+                    if os.path.isdir(dst_str) and not _is_reparse_point(dst_str):
+                        shutil.rmtree(dst_str, ignore_errors=True)
+                    elif os.path.lexists(dst_str):
+                        os.unlink(dst_str)
+                except OSError:
+                    pass
+            return sanic_json({"ok": False, "error": str(exc)}, status=400)
+        return sanic_json({"ok": True, "path": dst_str})
+
+    async def _file_move(request: Request):
+        # Move/rename a file or directory. Both paths resolve LINK-SAFE (#72): a
+        # symlink/junction src relocates the LINK entry, never its target tree.
+        # dst is the FULL target path. An existing dst needs overwrite=true (409
+        # otherwise). Overwrite never loses the old dst: two real files use the
+        # atomic os.replace; anything else (dir, symlink/junction, type change)
+        # renames the existing dst to a sibling backup, moves src into place, and
+        # only then drops the backup — restoring it if the move fails.
+        err = _file_auth_error(request)
+        if err is not None:
+            return err
+        body = _json_object_body(request)
+        if body is None:
+            return sanic_json({"ok": False, "error": "bad_json"}, status=400)
+        overwrite = bool(body.get("overwrite", False))
+        try:
+            src, dst = _resolve_two(body, app.ctx.editor_root,
+                                    src_follow_leaf=False, dst_follow_leaf=False)
+        except ValueError:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        if src == dst:
+            return sanic_json({"ok": False, "error": "same"}, status=400)
+        if _is_within(dst, src):
+            return sanic_json({"ok": False, "error": "dest_in_source"},
+                              status=400)
+        src_str, dst_str = str(src), str(dst)
+        # lexists (not exists): a broken symlink leaf still exists and must be
+        # movable; a real symlink/junction must not be dereferenced here.
+        if not os.path.lexists(src_str):
+            return sanic_json({"ok": False, "error": "not_found"}, status=404)
+        dparent = _classify_path(dst.parent)
+        if dparent == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if dparent != "dir":
+            return sanic_json({"ok": False, "error": "parent_missing"},
+                              status=400)
+        dst_exists = os.path.lexists(dst_str)
+        if dst_exists and not overwrite:
+            return sanic_json({"ok": False, "error": "exists"}, status=409)
+
+        def _do_move():
+            if not (dst_exists and overwrite):
+                _rename_or_move(src_str, dst_str)
+                return
+            both_real_files = (
+                os.path.isfile(src_str) and not _is_reparse_point(src_str)
+                and os.path.isfile(dst_str) and not _is_reparse_point(dst_str))
+            if both_real_files:
+                _rename_or_move(src_str, dst_str)   # atomic file replace
+                return
+            # No atomic replace for these (no dir-over-dir replace on Windows);
+            # back up the existing dst, move, restore on ANY failure so dst is
+            # never lost.
+            backup = dst_str + ".webterm-bak-" + uuid.uuid4().hex
+            os.rename(dst_str, backup)
+            try:
+                _rename_or_move(src_str, dst_str)
+            except BaseException:
+                try:
+                    if os.path.lexists(dst_str):
+                        _force_remove(dst_str)
+                except OSError:
+                    pass
+                try:
+                    os.rename(backup, dst_str)
+                except OSError:
+                    pass
+                raise
+            _force_remove(backup)
+
+        try:
+            await asyncio.get_running_loop().run_in_executor(None, _do_move)
+        except (OSError, ValueError, shutil.Error, RecursionError) as exc:
+            return sanic_json({"ok": False, "error": str(exc)}, status=400)
+        return sanic_json({"ok": True, "path": dst_str})
+
     # ---- task manager + git button (/session/*) --------------------------
     # On-demand broker<->producer round-trips (correlated by req id) so process
     # listing, scoped kill, and git status work for LOCAL and REMOTE sessions
@@ -1598,6 +1863,8 @@ def create_app(config: Optional[Dict[str, Any]] = None,
     app.add_route(_file_upload, "/file/upload", methods=["POST"])
     app.add_route(_file_delete, "/file/delete", methods=["POST"])
     app.add_route(_file_mkdir, "/file/mkdir", methods=["POST"])
+    app.add_route(_file_copy, "/file/copy", methods=["POST"])
+    app.add_route(_file_move, "/file/move", methods=["POST"])
     app.add_route(_session_procs, "/session/procs", methods=["POST"])
     app.add_route(_session_kill, "/session/kill", methods=["POST"])
     app.add_route(_session_git, "/session/git", methods=["POST"])
@@ -1627,6 +1894,8 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                              ("/file/upload", "preflight_file_upload"),
                              ("/file/delete", "preflight_file_delete"),
                              ("/file/mkdir", "preflight_file_mkdir"),
+                             ("/file/copy", "preflight_file_copy"),
+                             ("/file/move", "preflight_file_move"),
                              ("/session/procs", "preflight_session_procs"),
                              ("/session/kill", "preflight_session_kill"),
                              ("/session/git", "preflight_session_git"),

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -1042,16 +1042,19 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                            "size": len(data)})
 
     async def _file_delete(request: Request):
-        # Destructive sibling of /file/write (#46): same host-wide resolution,
-        # gate, and absolute-path echo. SINGLE FILE ONLY — is_file() refuses a
-        # directory (and a symlink-to-dir, which is_file() reports False), so
-        # this can never recurse a tree. Like read/write/upload, the path is
-        # fully resolved first (_resolve_host_path ends in .resolve()), so a
-        # symlink-to-file deletes its TARGET — the same link-following semantics
-        # those endpoints already use. Used by the file manager's cross-pane
-        # MOVE (copy-to-dest, then delete-source). No NEW privilege: /file/write
-        # already grants full host-wide overwrite under this exact auth gate —
-        # delete stays within it.
+        # Destructive sibling of /file/write (#46), extended for the file manager
+        # context menu (#72): a real directory is removed too, but only when the
+        # caller passes recursive=true (a plain delete of a non-empty dir is a
+        # 400 is_a_directory, so a mis-click can't wipe a tree).
+        #
+        # The headline correctness change (#72): the leaf is resolved BOTH ways.
+        # p_leaf (link-safe) is checked for being a symlink/junction FIRST — if
+        # so only the link ENTRY is removed, NEVER the target it points at. Only
+        # a genuinely real path falls through to unlink (file) / rmtree (dir),
+        # acting on the fully-resolved p. This closes the data-loss hole the old
+        # ".resolve() then operate" path had (deleting a symlink-to-dir would
+        # have rmtree'd the link's target tree, host-wide). No NEW privilege:
+        # /file/write already grants full host-wide overwrite under this gate.
         err = _file_auth_error(request)
         if err is not None:
             return err
@@ -1061,22 +1064,45 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         rel = body.get("path")
         if not isinstance(rel, str) or not rel:
             return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        recursive = bool(body.get("recursive", False))
         try:
             p = _resolve_host_path(rel, app.ctx.editor_root)
+            p_leaf = _resolve_host_path(rel, app.ctx.editor_root,
+                                        follow_leaf=False)
         except ValueError:
             return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        leaf_str = str(p_leaf)
+        # lexists, not exists: a broken symlink (target gone) still has a link
+        # entry that should be deletable, and a real link must be detected here
+        # before any classification follows it.
+        if not os.path.lexists(leaf_str):
+            return sanic_json({"ok": False, "error": "not_found"}, status=404)
+        if _is_reparse_point(leaf_str):
+            try:
+                await asyncio.get_running_loop().run_in_executor(
+                    None, _remove_link, leaf_str)
+            except (OSError, ValueError, shutil.Error, RecursionError) as exc:
+                return sanic_json({"ok": False, "error": str(exc)}, status=400)
+            return sanic_json({"ok": True, "path": leaf_str})
         kind = _classify_path(p)
         if kind == "denied":
             return sanic_json({"ok": False, "error": "permission_denied"},
                               status=400)
         if kind == "missing":
             return sanic_json({"ok": False, "error": "not_found"}, status=404)
-        if kind != "file":
+        if kind == "dir":
+            if not recursive:
+                return sanic_json({"ok": False, "error": "is_a_directory"},
+                                  status=400)
+            fn, arg = shutil.rmtree, str(p)
+        elif kind == "file":
+            fn, arg = os.unlink, str(p)
+        else:
             return sanic_json({"ok": False, "error": "not_a_file"},
                               status=400)
         try:
-            os.unlink(str(p))
-        except OSError as exc:
+            await asyncio.get_running_loop().run_in_executor(None, fn, arg)
+        except (OSError, ValueError, shutil.Error, RecursionError) as exc:
             return sanic_json({"ok": False, "error": str(exc)}, status=400)
         return sanic_json({"ok": True,
                            "path": str(p)})      # absolute, host-wide (#35)

--- a/webterm/broker/app.py
+++ b/webterm/broker/app.py
@@ -43,8 +43,10 @@ import logging
 import os
 import re
 import secrets
+import shutil
 import tempfile
 import uuid
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -67,6 +69,13 @@ DEFAULT_PORT = 4445
 # Editor file-API: a single read/write is capped at this many bytes (the cap
 # is enforced on the UTF-8 encoded payload, not the character count).
 MAX_FILE_BYTES = 5 * 2**20  # 5 MiB
+
+# /file/zip + /file/unzip caps (#72). Bound the work a single archive op will do
+# so a hostile (or accidental) huge source tree or zip-bomb can't exhaust disk
+# or memory: cumulative UNCOMPRESSED size and member/entry count are both
+# pre-scanned and rejected BEFORE any write or extract. Tunable.
+MAX_ARCHIVE_BYTES = 1 * 2**30      # 1 GiB cumulative uncompressed
+MAX_ARCHIVE_ENTRIES = 50000        # member/entry count
 
 # /state: the shared per-broker UI settings+layout blob is small (a layout
 # tree + a settings object); cap the serialized JSON so a hostile PUT can't
@@ -962,6 +971,55 @@ def create_app(config: Optional[Dict[str, Any]] = None,
         return sanic_json({"ok": True,
                            "path": str(p)})      # absolute, host-wide (#35)
 
+    # ---- richer file operations (#72) ------------------------------------
+    # mkdir / copy / move / zip / unzip / stat round out the file manager's
+    # context menu. Same token-or-loopback gate, host-wide resolution
+    # (_resolve_host_path) and absolute-path echo as the read/write/delete
+    # endpoints above; they add NO new privilege (an authenticated client
+    # already has shell-level filesystem access). Heavy IO (copytree / rmtree /
+    # zip / unzip) runs OFF the event loop via run_in_executor, and the catch is
+    # broadened past OSError (shutil.Error, RecursionError, ValueError) so a
+    # non-OSError failure still keeps the {ok:false,error} contract instead of
+    # surfacing as a 500 + traceback.
+    async def _file_mkdir(request: Request):
+        # Create ONE directory. os.mkdir (NOT makedirs) — the parent must
+        # already be a dir (parent_missing else), so a typo can't silently
+        # build a chain of dirs. An existing path is a 409 conflict.
+        err = _file_auth_error(request)
+        if err is not None:
+            return err
+        body = _json_object_body(request)
+        if body is None:
+            return sanic_json({"ok": False, "error": "bad_json"}, status=400)
+        rel = body.get("path")
+        if not isinstance(rel, str) or not rel:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        try:
+            p = _resolve_host_path(rel, app.ctx.editor_root)
+        except ValueError:
+            return sanic_json({"ok": False, "error": "bad_path"}, status=400)
+        kind = _classify_path(p)
+        if kind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if kind != "missing":
+            return sanic_json({"ok": False, "error": "exists"}, status=409)
+        parent = p.parent
+        pkind = _classify_path(parent)
+        if pkind == "denied":
+            return sanic_json({"ok": False, "error": "permission_denied"},
+                              status=400)
+        if pkind != "dir":
+            return sanic_json({"ok": False, "error": "parent_missing"},
+                              status=400)
+        try:
+            await asyncio.get_running_loop().run_in_executor(
+                None, os.mkdir, str(p))
+        except (OSError, ValueError, shutil.Error, RecursionError) as exc:
+            return sanic_json({"ok": False, "error": str(exc)}, status=400)
+        return sanic_json({"ok": True,
+                           "path": str(p)})      # absolute, host-wide (#35)
+
     # ---- task manager + git button (/session/*) --------------------------
     # On-demand broker<->producer round-trips (correlated by req id) so process
     # listing, scoped kill, and git status work for LOCAL and REMOTE sessions
@@ -1539,6 +1597,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
     app.add_route(_file_write, "/file/write", methods=["POST"])
     app.add_route(_file_upload, "/file/upload", methods=["POST"])
     app.add_route(_file_delete, "/file/delete", methods=["POST"])
+    app.add_route(_file_mkdir, "/file/mkdir", methods=["POST"])
     app.add_route(_session_procs, "/session/procs", methods=["POST"])
     app.add_route(_session_kill, "/session/kill", methods=["POST"])
     app.add_route(_session_git, "/session/git", methods=["POST"])
@@ -1567,6 +1626,7 @@ def create_app(config: Optional[Dict[str, Any]] = None,
                              ("/file/write", "preflight_file_write"),
                              ("/file/upload", "preflight_file_upload"),
                              ("/file/delete", "preflight_file_delete"),
+                             ("/file/mkdir", "preflight_file_mkdir"),
                              ("/session/procs", "preflight_session_procs"),
                              ("/session/kill", "preflight_session_kill"),
                              ("/session/git", "preflight_session_git"),

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -68,12 +68,40 @@
                     return _modFileApi('/file/list', { path: path || '' }, opts);
                 },
                 'delete': function (path, opts) {
-                    return _modFileApi('/file/delete', { path: path }, opts);
+                    return _modFileApi('/file/delete',
+                        { path: path,
+                          recursive: !!(opts && opts.recursive) }, opts);
                 },
                 upload: function (path, contentB64, opts) {
                     return _modFileApi('/file/upload',
                         { path: path, content_b64: contentB64,
                           overwrite: !!(opts && opts.overwrite) }, opts);
+                },
+                // #72 richer ops mirror (mods-off parity with ctx.file).
+                mkdir: function (path, opts) {
+                    return _modFileApi('/file/mkdir', { path: path }, opts);
+                },
+                copy: function (src, dst, opts) {
+                    return _modFileApi('/file/copy',
+                        { src: src, dst: dst,
+                          overwrite: !!(opts && opts.overwrite) }, opts);
+                },
+                move: function (src, dst, opts) {
+                    return _modFileApi('/file/move',
+                        { src: src, dst: dst,
+                          overwrite: !!(opts && opts.overwrite) }, opts);
+                },
+                zip: function (src, dest, opts) {
+                    return _modFileApi('/file/zip',
+                        { src: src, dest: dest,
+                          overwrite: !!(opts && opts.overwrite) }, opts);
+                },
+                unzip: function (path, dest, opts) {
+                    return _modFileApi('/file/unzip',
+                        { path: path, dest: dest }, opts);
+                },
+                stat: function (path, opts) {
+                    return _modFileApi('/file/stat', { path: path }, opts);
                 },
             };
         }

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -406,6 +406,24 @@
                         openFile(child);
                     }
                 };
+                // Make a row draggable to the other pane / another FM window
+                // (#72): files AND dirs. effectAllowed='copyMove' so a plain drag
+                // copies and a Shift-drag moves (the drop handler reads e.shiftKey
+                // and the payload carries the type for the cross-host dir refusal).
+                const makeDraggable = (row, ent, child) => {
+                    row.draggable = true;
+                    row.addEventListener('dragstart', (e) => {
+                        setActive(side); selectRow(row);
+                        if (!e.dataTransfer) return;
+                        e.dataTransfer.effectAllowed = 'copyMove';
+                        e.dataTransfer.setData(FM_DRAG_MIME, JSON.stringify({
+                            winId: id, side, hostId: win[hostKey(side)],
+                            path: child, name: ent.name, type: ent.type }));
+                        row.classList.add('dragging');
+                    });
+                    row.addEventListener('dragend',
+                        () => row.classList.remove('dragging'));
+                };
                 // Rename in place = a /file/move to a validated sibling name in
                 // this same dir (cwd). Client-side name validation is UX; the
                 // server re-checks.
@@ -679,24 +697,9 @@
                             setActive(side); selectRow(row);
                         });
                         row.addEventListener('dblclick', () => openFile(child));
-                        // Drag a file to the OTHER pane to COPY it (#46) — works
-                        // across hosts. effectAllowed='copy' (drag is copy-only;
-                        // move is the explicit context-menu action, since a drag
-                        // modifier can't be read reliably during dragover).
-                        row.draggable = true;
-                        row.addEventListener('dragstart', (e) => {
-                            setActive(side); selectRow(row);
-                            if (!e.dataTransfer) return;
-                            e.dataTransfer.effectAllowed = 'copy';
-                            e.dataTransfer.setData(FM_DRAG_MIME, JSON.stringify({
-                                winId: id, side, hostId: win[hostKey(side)],
-                                path: child, name: ent.name }));
-                            row.classList.add('dragging');
-                        });
-                        row.addEventListener('dragend',
-                            () => row.classList.remove('dragging'));
                     }
-                    // Shared row menu on BOTH file and dir rows (#72).
+                    // Draggable + shared row menu on BOTH file and dir rows (#72).
+                    makeDraggable(row, ent, child);
                     row.addEventListener('contextmenu',
                         (e) => onRowMenu(e, row, ent, child));
                     ui.list.appendChild(row);
@@ -1103,7 +1106,10 @@
                 const onClick = () => { setActive(side); fmBody.focus(); };
                 const onOver = (e) => {
                     e.preventDefault();
-                    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+                    // Shift = move, else copy — mirror it in the cursor (#72).
+                    if (e.dataTransfer) {
+                        e.dataTransfer.dropEffect = e.shiftKey ? 'move' : 'copy';
+                    }
                     ui.pane.classList.add('drop-hover');
                 };
                 const onLeave = () => ui.pane.classList.remove('drop-hover');
@@ -1130,7 +1136,9 @@
                     // of the same side name — is a real transfer (#46 review).
                     if (payload && payload.path
                         && !(payload.winId === id && payload.side === side)) {
-                        transferFromPayload(payload, side, false);  // drag = copy
+                        // Shift-drop = move, plain drop = copy (#72). doTransfer
+                        // routes by type: a cross-host dir gets a clear refusal.
+                        transferFromPayload(payload, side, e.shiftKey);
                     }
                 };
                 // Right-click the pane's empty background -> the empty-area menu

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -406,6 +406,44 @@
                         openFile(child);
                     }
                 };
+                // Rename in place = a /file/move to a validated sibling name in
+                // this same dir (cwd). Client-side name validation is UX; the
+                // server re-checks.
+                const renameRow = async (ent, child) => {
+                    const host = paneHost(side);
+                    if (!host) {
+                        showNotice('rename failed: host unavailable');
+                        return;
+                    }
+                    const name = await openTextPrompt({
+                        title: 'Rename', label: 'New name', value: ent.name,
+                        okLabel: 'Rename', validate: validateName });
+                    if (name == null || win.disposed) return;
+                    const trimmed = name.trim();
+                    if (trimmed === ent.name) return;        // no change
+                    const dst = joinNative(cwd, trimmed);
+                    let res = await fmFile().move(child, dst, { host: host.id });
+                    if (win.disposed) return;
+                    if (res && res.error === 'exists') {
+                        const ok = await openConfirmDialog({
+                            title: 'Rename',
+                            message: 'Overwrite ' + trimmed + '?',
+                            okLabel: 'Overwrite', danger: true });
+                        if (!ok || win.disposed) return;
+                        res = await fmFile().move(child, dst,
+                            { host: host.id, overwrite: true });
+                        if (win.disposed) return;
+                    }
+                    if (!(res && res.ok)) {
+                        if (res && res.error === 'auth_required') {
+                            promptFileHostAuth(host);
+                        }
+                        showNotice('rename failed: ' + ((res && res.error) || '?'));
+                        return;
+                    }
+                    showNotice('renamed to ' + trimmed);
+                    renderPane(side);
+                };
                 const buildRowMenu = (row, ent, child) => {
                     const other = side === 'left' ? 'right' : 'left';
                     const desc = { hostId: win[hostKey(side)], path: child,
@@ -423,6 +461,8 @@
                                  action: () => setClipboard('copy', desc) });
                     items.push({ label: 'Paste', enabled: !!win.fmClipboard,
                                  action: () => pasteInto(side, pasteDir) });
+                    items.push({ label: 'Rename…', enabled: true,
+                                 action: () => renameRow(ent, child) });
                     items.push({ sep: true });
                     items.push({ label: 'Copy → ' + other + ' pane',
                                  enabled: true,
@@ -802,6 +842,45 @@
                 if (ok && clip.mode === 'cut') win.fmClipboard = null;
             };
 
+            // Client-side name check (UX only — the server re-validates). Rejects
+            // both separators (/ and \), the ADS colon, '.'/'..', and empty.
+            // Returns '' when OK (openTextPrompt treats a truthy return as the
+            // error to show and keeps the dialog open).
+            const validateName = (name) => {
+                const n = (name || '').trim();
+                if (!n) return 'enter a name';
+                if (n === '.' || n === '..') return 'invalid name';
+                if (/[\/\\]/.test(n)) return 'name can’t contain / or \\';
+                if (n.indexOf(':') !== -1) return 'name can’t contain :';
+                return '';
+            };
+            // New folder in a pane's cwd via a styled prompt -> /file/mkdir.
+            const newFolder = async (side) => {
+                const host = paneHost(side);
+                if (!host) {
+                    showNotice('new folder failed: host unavailable');
+                    return;
+                }
+                const name = await openTextPrompt({
+                    title: 'New folder', label: 'Folder name',
+                    okLabel: 'Create', validate: validateName });
+                if (name == null || win.disposed) return;
+                const dst = joinNative(win[dirKey(side)], name.trim());
+                const res = await fmFile().mkdir(dst, { host: host.id });
+                if (win.disposed) return;
+                if (!(res && res.ok)) {
+                    if (res && res.error === 'auth_required') {
+                        promptFileHostAuth(host);
+                    }
+                    const err = (res && res.error) || '?';
+                    showNotice('new folder failed: '
+                        + (err === 'exists' ? 'already exists' : err));
+                    return;
+                }
+                showNotice('created ' + name.trim());
+                renderPane(side);
+            };
+
             // Right-click on a pane's empty background: New folder / Paste /
             // Refresh / Properties of the cwd. Lives in the outer scope (reads
             // win[dirKey(side)] live) so the one pane-level contextmenu handler
@@ -809,11 +888,13 @@
             const buildEmptyMenu = (side) => {
                 const cwd = win[dirKey(side)];
                 const items = [];
+                items.push({ label: 'New folder…', enabled: true,
+                             action: () => newFolder(side) });
                 if (win.fmClipboard) {
                     items.push({ label: 'Paste', enabled: true,
                                  action: () => pasteInto(side, cwd) });
                 }
-                if (items.length) items.push({ sep: true });
+                items.push({ sep: true });
                 items.push({ label: 'Refresh', enabled: true,
                              action: () => { renderPane('left');
                                              renderPane('right'); } });

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -390,6 +390,30 @@
                         fileHostId: win[hostKey(side)],
                     });
                 };
+                // Right-click row menu (#72). One builder shared by file and dir
+                // rows; the item set grows in later commits. Today (pure
+                // extraction): copy/move the row to the other pane. Captures the
+                // descriptor (host id + child path + name) at build time so a
+                // pane navigation mid-menu can't redirect the action.
+                const buildRowMenu = (row, ent, child) => {
+                    const other = side === 'left' ? 'right' : 'left';
+                    const srcHostId = win[hostKey(side)];
+                    return [
+                        { label: 'Copy → ' + other + ' pane', enabled: true,
+                          action: () => transferTo(other, srcHostId, child,
+                                                   ent.name, false) },
+                        { label: 'Move → ' + other + ' pane', enabled: true,
+                          action: () => transferTo(other, srcHostId, child,
+                                                   ent.name, true) },
+                    ];
+                };
+                const onRowMenu = (e, row, ent, child) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setActive(side); selectRow(row);
+                    renderMenu(buildRowMenu(row, ent, child),
+                               e.clientX, e.clientY);
+                };
                 // '..' row (not at root): navigates to the parent dir.
                 if (res.parent !== null && res.parent !== undefined) {
                     const up = document.createElement('div');
@@ -450,25 +474,9 @@
                         });
                         row.addEventListener('dragend',
                             () => row.classList.remove('dragging'));
-                        // Right-click a file: copy / move it to the other pane.
-                        row.addEventListener('contextmenu', (e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            setActive(side); selectRow(row);
-                            const other = side === 'left' ? 'right' : 'left';
-                            renderMenu([
-                                { label: 'Copy → ' + other + ' pane',
-                                  enabled: true,
-                                  action: () => transferTo(other,
-                                      win[hostKey(side)], child, ent.name,
-                                      false) },
-                                { label: 'Move → ' + other + ' pane',
-                                  enabled: true,
-                                  action: () => transferTo(other,
-                                      win[hostKey(side)], child, ent.name,
-                                      true) },
-                            ], e.clientX, e.clientY);
-                        });
+                        // Right-click a file: the shared row menu.
+                        row.addEventListener('contextmenu',
+                            (e) => onRowMenu(e, row, ent, child));
                     }
                     ui.list.appendChild(row);
                 }

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -397,14 +397,13 @@
                 // pane navigation mid-menu can't redirect the action.
                 const buildRowMenu = (row, ent, child) => {
                     const other = side === 'left' ? 'right' : 'left';
-                    const srcHostId = win[hostKey(side)];
+                    const desc = { hostId: win[hostKey(side)], path: child,
+                                   name: ent.name, type: ent.type };
                     return [
                         { label: 'Copy → ' + other + ' pane', enabled: true,
-                          action: () => transferTo(other, srcHostId, child,
-                                                   ent.name, false) },
+                          action: () => doTransfer(other, desc, false) },
                         { label: 'Move → ' + other + ' pane', enabled: true,
-                          action: () => transferTo(other, srcHostId, child,
-                                                   ent.name, true) },
+                          action: () => doTransfer(other, desc, true) },
                     ];
                 };
                 const onRowMenu = (e, row, ent, child) => {
@@ -532,9 +531,13 @@
                     const path = joinPath(cwd, file.name);
                     let res = await uploadTo(host.id, path, b64, false);
                     if (win.disposed) return;         // closed before the prompt
-                    // Existing file -> confirm + retry as an overwrite.
+                    // Existing file -> styled confirm + retry as an overwrite.
                     if (res && res.error === 'exists') {
-                        if (!confirm('Overwrite ' + file.name + '?')) continue;
+                        const ok = await openConfirmDialog({
+                            title: 'Overwrite',
+                            message: 'Overwrite ' + file.name + '?',
+                            okLabel: 'Overwrite', danger: true });
+                        if (!ok || win.disposed) { if (win.disposed) return; continue; }
                         res = await uploadTo(host.id, path, b64, true);
                     }
                     if (win.disposed) return;
@@ -556,6 +559,12 @@
             // OWN per-host auth. The descriptor is captured at call time and
             // never recomputed after a prompt/await, so navigating a pane
             // mid-transfer can't redirect the write (codex review).
+            // Cross-host SINGLE-FILE byte path (the only transfer a single
+            // broker can't do server-side). Reached from doTransfer for a
+            // cross-host file. Returns true on a complete success, false
+            // otherwise (incl. the honest "copied but couldn't remove source"
+            // partial-move), so a cut-paste only clears its clipboard when the
+            // move actually completed.
             const transferTo = async (destSide, srcHostId, srcPath, srcName,
                                       move) => {
                 const srcHost = hostById(srcHostId)
@@ -564,11 +573,11 @@
                 const destHost = paneHost(destSide);
                 if (!srcHost) {
                     showNotice('transfer failed: source host unavailable');
-                    return;
+                    return false;
                 }
                 if (!destHost) {
                     showNotice('transfer failed: destination host unavailable');
-                    return;
+                    return false;
                 }
                 const destPath = joinNative(win[dirKey(destSide)], srcName);
                 // Refuse a copy/move onto the SAME file (same host + same
@@ -576,11 +585,11 @@
                 // and a self-MOVE would then delete the file it just wrote.
                 if (srcHost.id === destHost.id && destPath === srcPath) {
                     showNotice('source and destination are the same file');
-                    return;
+                    return false;
                 }
                 const r = await fmFile().read(srcPath,
                     { b64: true, host: srcHost.id });
-                if (win.disposed) return;
+                if (win.disposed) return false;
                 if (!r || !r.ok) {
                     if (r && r.error === 'auth_required') {
                         promptFileHostAuth(srcHost);
@@ -592,7 +601,7 @@
                         showNotice('transfer failed (read ' + srcName + '): '
                             + err);
                     }
-                    return;
+                    return false;
                 }
                 // The source broker accepted the read but returned no
                 // content_b64: it predates the binary-safe read (#46 review).
@@ -603,17 +612,21 @@
                 if (typeof r.content_b64 !== 'string') {
                     showNotice('transfer failed: ' + srcName + ' — source broker '
                         + 'lacks binary read (upgrade it)');
-                    return;
+                    return false;
                 }
                 const b64 = r.content_b64;
                 let up = await uploadTo(destHost.id, destPath, b64, false);
-                if (win.disposed) return;
-                // Existing dest file -> confirm + retry as an overwrite.
+                if (win.disposed) return false;
+                // Existing dest file -> styled confirm + retry as an overwrite.
                 if (up && up.error === 'exists') {
-                    if (!confirm('Overwrite ' + srcName + ' on "'
-                            + hostPickerLabel(destHost) + '"?')) return;
+                    const ok = await openConfirmDialog({
+                        title: 'Overwrite',
+                        message: 'Overwrite ' + srcName + ' on "'
+                            + hostPickerLabel(destHost) + '"?',
+                        okLabel: 'Overwrite', danger: true });
+                    if (!ok || win.disposed) return false;
                     up = await uploadTo(destHost.id, destPath, b64, true);
-                    if (win.disposed) return;
+                    if (win.disposed) return false;
                 }
                 if (!(up && up.ok)) {
                     const err = (up && up.error) || 'error';
@@ -624,14 +637,14 @@
                         showNotice('transfer failed (write ' + srcName + '): '
                             + err);
                     }
-                    return;
+                    return false;
                 }
                 // Move = copy succeeded, now delete the source. Best-effort and
                 // HONEST: the copy already landed, so a failed delete leaves the
                 // file on BOTH hosts — say so rather than claim a move (codex).
                 if (move) {
                     const d = await fmFile().delete(srcPath, { host: srcHost.id });
-                    if (win.disposed) return;
+                    if (win.disposed) return false;
                     if (!(d && d.ok)) {
                         if (d && d.error === 'auth_required') {
                             promptFileHostAuth(srcHost);
@@ -640,7 +653,7 @@
                             + 'the source: ' + ((d && d.error) || '?'));
                         renderPane('left');
                         renderPane('right');
-                        return;
+                        return false;
                     }
                 }
                 showNotice((move ? 'moved ' : 'copied ') + srcName + ' to "'
@@ -649,11 +662,88 @@
                 // lost one. Cheap, and side-agnostic (either pane may be source).
                 renderPane('left');
                 renderPane('right');
+                return true;
+            };
+            // ---- unified transfer dispatcher (#72) ----
+            // ONE entry point for every copy/move: the two pane actions, Paste,
+            // and a drop all route through here. src is a descriptor captured at
+            // call time {hostId, path, name, type}. Routing:
+            //   same host        -> server-side /file/copy|/file/move (handles
+            //                       DIRECTORIES, no 5 MiB cap; exists -> styled
+            //                       confirm -> retry overwrite)
+            //   cross host + file-> the existing binary byte path (transferTo)
+            //   cross host + dir -> a clear "not supported yet" notice
+            // Returns true on success so a caller (Paste) can clear a cut
+            // clipboard only when the move actually landed.
+            const doTransfer = async (destSide, src, move) => {
+                if (!src || !src.path) return false;
+                const srcHost = hostById(src.hostId)
+                    || ((!src.hostId || src.hostId === 'local')
+                        ? localHost() : null);
+                const destHost = paneHost(destSide);
+                if (!srcHost) {
+                    showNotice('transfer failed: source host unavailable');
+                    return false;
+                }
+                if (!destHost) {
+                    showNotice('transfer failed: destination host unavailable');
+                    return false;
+                }
+                const srcName = src.name || baseName(src.path);
+                const destPath = joinNative(win[dirKey(destSide)], srcName);
+                // Self-overwrite guard: same host + same absolute path (a copy
+                // would be a pointless self-overwrite; a self-move would delete
+                // what it just wrote). The server re-checks ('same'), but this
+                // is a cleaner message and saves a round trip.
+                if (srcHost.id === destHost.id && destPath === src.path) {
+                    showNotice('source and destination are the same');
+                    return false;
+                }
+                if (srcHost.id === destHost.id) {
+                    // Same host: server-side op (files AND dirs, no size cap).
+                    const op = (overwrite) => move
+                        ? fmFile().move(src.path, destPath,
+                                        { host: srcHost.id, overwrite: overwrite })
+                        : fmFile().copy(src.path, destPath,
+                                        { host: srcHost.id, overwrite: overwrite });
+                    let res = await op(false);
+                    if (win.disposed) return false;
+                    if (res && res.error === 'exists') {
+                        const ok = await openConfirmDialog({
+                            title: move ? 'Move' : 'Copy',
+                            message: 'Overwrite ' + srcName + '?',
+                            okLabel: 'Overwrite', danger: true });
+                        if (!ok || win.disposed) return false;
+                        res = await op(true);
+                        if (win.disposed) return false;
+                    }
+                    if (!(res && res.ok)) {
+                        const err = (res && res.error) || 'error';
+                        if (err === 'auth_required') promptFileHostAuth(srcHost);
+                        showNotice((move ? 'move' : 'copy') + ' failed ('
+                            + srcName + '): ' + err);
+                        return false;
+                    }
+                    showNotice((move ? 'moved ' : 'copied ') + srcName);
+                    renderPane('left');
+                    renderPane('right');
+                    return true;
+                }
+                // Cross host. The single-broker server-side ops can't straddle
+                // two hosts, and the byte path only carries a single file.
+                if (src.type === 'dir') {
+                    showNotice('cross-host folder copy isn’t supported yet');
+                    return false;
+                }
+                return await transferTo(destSide, src.hostId, src.path,
+                                        srcName, move);
             };
             const transferFromPayload = (payload, destSide, move) => {
                 if (!payload || !payload.path) return;
-                transferTo(destSide, payload.hostId, payload.path,
-                    payload.name || baseName(payload.path), move);
+                doTransfer(destSide, {
+                    hostId: payload.hostId, path: payload.path,
+                    name: payload.name || baseName(payload.path),
+                    type: payload.type }, move);
             };
 
             for (const side of ['left', 'right']) {

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -395,16 +395,42 @@
                 // extraction): copy/move the row to the other pane. Captures the
                 // descriptor (host id + child path + name) at build time so a
                 // pane navigation mid-menu can't redirect the action.
+                // Open a row = exactly what its dblclick does: a dir navigates,
+                // a file opens in the editor.
+                const activateRow = (ent, child) => {
+                    if (ent.type === 'dir') {
+                        win[dirKey(side)] = child;
+                        saveAppWindow(win);
+                        renderPane(side);
+                    } else {
+                        openFile(child);
+                    }
+                };
                 const buildRowMenu = (row, ent, child) => {
                     const other = side === 'left' ? 'right' : 'left';
                     const desc = { hostId: win[hostKey(side)], path: child,
                                    name: ent.name, type: ent.type };
-                    return [
-                        { label: 'Copy → ' + other + ' pane', enabled: true,
-                          action: () => doTransfer(other, desc, false) },
-                        { label: 'Move → ' + other + ' pane', enabled: true,
-                          action: () => doTransfer(other, desc, true) },
-                    ];
+                    // Paste lands in the dir itself for a folder row, else the
+                    // current cwd (a file row's sibling dir).
+                    const pasteDir = ent.type === 'dir' ? child : cwd;
+                    const items = [];
+                    items.push({ label: 'Open', enabled: true,
+                                 action: () => activateRow(ent, child) });
+                    items.push({ sep: true });
+                    items.push({ label: 'Cut', enabled: true,
+                                 action: () => setClipboard('cut', desc) });
+                    items.push({ label: 'Copy', enabled: true,
+                                 action: () => setClipboard('copy', desc) });
+                    items.push({ label: 'Paste', enabled: !!win.fmClipboard,
+                                 action: () => pasteInto(side, pasteDir) });
+                    items.push({ sep: true });
+                    items.push({ label: 'Copy → ' + other + ' pane',
+                                 enabled: true,
+                                 action: () => doTransfer(other, desc, false) });
+                    items.push({ label: 'Move → ' + other + ' pane',
+                                 enabled: true,
+                                 action: () => doTransfer(other, desc, true) });
+                    return items;
                 };
                 const onRowMenu = (e, row, ent, child) => {
                     e.preventDefault();
@@ -427,6 +453,11 @@
                     };
                     up.addEventListener('click', () => { setActive(side); selectRow(up); });
                     up.addEventListener('dblclick', onUp);
+                    // '..' has no row menu (#72) — swallow the right-click so it
+                    // doesn't fall through to the pane's empty-area menu.
+                    up.addEventListener('contextmenu', (e) => {
+                        e.preventDefault(); e.stopPropagation();
+                    });
                     ui.list.appendChild(up);
                 }
                 for (const ent of (res.entries || [])) {
@@ -473,10 +504,10 @@
                         });
                         row.addEventListener('dragend',
                             () => row.classList.remove('dragging'));
-                        // Right-click a file: the shared row menu.
-                        row.addEventListener('contextmenu',
-                            (e) => onRowMenu(e, row, ent, child));
                     }
+                    // Shared row menu on BOTH file and dir rows (#72).
+                    row.addEventListener('contextmenu',
+                        (e) => onRowMenu(e, row, ent, child));
                     ui.list.appendChild(row);
                 }
             };
@@ -674,8 +705,10 @@
             //   cross host + file-> the existing binary byte path (transferTo)
             //   cross host + dir -> a clear "not supported yet" notice
             // Returns true on success so a caller (Paste) can clear a cut
-            // clipboard only when the move actually landed.
-            const doTransfer = async (destSide, src, move) => {
+            // clipboard only when the move actually landed. destDir overrides the
+            // target directory (Paste into a folder row); default = destSide's
+            // current cwd. The destination HOST is always destSide's pane host.
+            const doTransfer = async (destSide, src, move, destDir) => {
                 if (!src || !src.path) return false;
                 const srcHost = hostById(src.hostId)
                     || ((!src.hostId || src.hostId === 'local')
@@ -690,7 +723,9 @@
                     return false;
                 }
                 const srcName = src.name || baseName(src.path);
-                const destPath = joinNative(win[dirKey(destSide)], srcName);
+                const targetDir = (destDir != null)
+                    ? destDir : win[dirKey(destSide)];
+                const destPath = joinNative(targetDir, srcName);
                 // Self-overwrite guard: same host + same absolute path (a copy
                 // would be a pointless self-overwrite; a self-move would delete
                 // what it just wrote). The server re-checks ('same'), but this
@@ -746,6 +781,45 @@
                     type: payload.type }, move);
             };
 
+            // ---- single-item clipboard (#72) ----
+            // win.fmClipboard = {mode:'cut'|'copy', hostId, path, name, type}.
+            // Cut/Copy stash a descriptor; Paste routes it through doTransfer
+            // into a chosen directory; a successful cut-paste clears the
+            // clipboard (one-shot move), a copy keeps it (paste again).
+            const setClipboard = (mode, desc) => {
+                win.fmClipboard = { mode: mode, hostId: desc.hostId,
+                                    path: desc.path, name: desc.name,
+                                    type: desc.type };
+                showNotice((mode === 'cut' ? 'cut ' : 'copied ') + desc.name);
+            };
+            const pasteInto = async (destSide, destDir) => {
+                const clip = win.fmClipboard;
+                if (!clip) return;
+                const ok = await doTransfer(destSide, {
+                    hostId: clip.hostId, path: clip.path,
+                    name: clip.name, type: clip.type },
+                    clip.mode === 'cut', destDir);
+                if (ok && clip.mode === 'cut') win.fmClipboard = null;
+            };
+
+            // Right-click on a pane's empty background: New folder / Paste /
+            // Refresh / Properties of the cwd. Lives in the outer scope (reads
+            // win[dirKey(side)] live) so the one pane-level contextmenu handler
+            // can call it; the item set grows in later commits.
+            const buildEmptyMenu = (side) => {
+                const cwd = win[dirKey(side)];
+                const items = [];
+                if (win.fmClipboard) {
+                    items.push({ label: 'Paste', enabled: true,
+                                 action: () => pasteInto(side, cwd) });
+                }
+                if (items.length) items.push({ sep: true });
+                items.push({ label: 'Refresh', enabled: true,
+                             action: () => { renderPane('left');
+                                             renderPane('right'); } });
+                return items;
+            };
+
             for (const side of ['left', 'right']) {
                 const ui = sideOf(side);
                 // Activate + focus the FM root so the Tab/Enter shortcuts fire
@@ -783,15 +857,27 @@
                         transferFromPayload(payload, side, false);  // drag = copy
                     }
                 };
+                // Right-click the pane's empty background -> the empty-area menu
+                // (#72). Rows stopPropagation in onRowMenu, so this fires only on
+                // the background; stopPropagation here keeps the desktop's own
+                // context menu from overwriting it.
+                const onPaneMenu = (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setActive(side);
+                    renderMenu(buildEmptyMenu(side), e.clientX, e.clientY);
+                };
                 ui.pane.addEventListener('mousedown', onClick);
                 ui.pane.addEventListener('dragover', onOver);
                 ui.pane.addEventListener('dragleave', onLeave);
                 ui.pane.addEventListener('drop', onDrop);
+                ui.pane.addEventListener('contextmenu', onPaneMenu);
                 win.cleanups.push(() => {
                     ui.pane.removeEventListener('mousedown', onClick);
                     ui.pane.removeEventListener('dragover', onOver);
                     ui.pane.removeEventListener('dragleave', onLeave);
                     ui.pane.removeEventListener('drop', onDrop);
+                    ui.pane.removeEventListener('contextmenu', onPaneMenu);
                 });
                 // Per-pane host picker (#46): the header button opens the host
                 // menu under itself; choosing another host re-roots this pane.

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -444,6 +444,141 @@
                     showNotice('renamed to ' + trimmed);
                     renderPane(side);
                 };
+                // Delete with a styled confirm; a directory deletes recursively.
+                const deleteRow = async (ent, child) => {
+                    const host = paneHost(side);
+                    if (!host) {
+                        showNotice('delete failed: host unavailable');
+                        return;
+                    }
+                    const isDir = ent.type === 'dir';
+                    const ok = await openConfirmDialog({
+                        title: 'Delete',
+                        message: 'Delete ' + (isDir ? 'folder ' : '') + ent.name
+                            + (isDir ? ' and everything inside it?' : '?'),
+                        okLabel: 'Delete', danger: true });
+                    if (!ok || win.disposed) return;
+                    const res = await fmFile().delete(child,
+                        { host: host.id, recursive: isDir });
+                    if (win.disposed) return;
+                    if (!(res && res.ok)) {
+                        if (res && res.error === 'auth_required') {
+                            promptFileHostAuth(host);
+                        }
+                        showNotice('delete failed: ' + ((res && res.error) || '?'));
+                        return;
+                    }
+                    showNotice('deleted ' + ent.name);
+                    renderPane(side);
+                };
+                // Download a file to the local machine: read base64, decode to
+                // bytes, save via an anchor. Bounded by /file/read's 5 MiB cap —
+                // a larger file surfaces a clear notice (a streaming download GET
+                // is a future enhancement, #72 risks).
+                const downloadRow = async (ent, child) => {
+                    const host = paneHost(side);
+                    if (!host) {
+                        showNotice('download failed: host unavailable');
+                        return;
+                    }
+                    const r = await fmFile().read(child,
+                        { b64: true, host: host.id });
+                    if (win.disposed) return;
+                    if (!(r && r.ok) || typeof r.content_b64 !== 'string') {
+                        const err = (r && r.error) || '?';
+                        if (err === 'auth_required') promptFileHostAuth(host);
+                        if (err === 'too_large') {
+                            showNotice(ent.name
+                                + ': too large to download (>5 MiB)');
+                        } else {
+                            showNotice('download failed: ' + err);
+                        }
+                        return;
+                    }
+                    try {
+                        const bin = atob(r.content_b64);
+                        const arr = new Uint8Array(bin.length);
+                        for (let i = 0; i < bin.length; i++) {
+                            arr[i] = bin.charCodeAt(i);
+                        }
+                        const url = URL.createObjectURL(
+                            new Blob([arr], { type: 'application/octet-stream' }));
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = ent.name;
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                        setTimeout(() => URL.revokeObjectURL(url), 10000);
+                    } catch (_) {
+                        showNotice('download failed: could not decode '
+                            + ent.name);
+                    }
+                };
+                // Zip a file/folder into a .zip in this dir (prompt for the name).
+                const zipRow = async (ent, child) => {
+                    const host = paneHost(side);
+                    if (!host) {
+                        showNotice('zip failed: host unavailable');
+                        return;
+                    }
+                    const name = await openTextPrompt({
+                        title: 'Zip', label: 'Archive name',
+                        value: ent.name + '.zip', okLabel: 'Zip',
+                        validate: validateName });
+                    if (name == null || win.disposed) return;
+                    const dest = joinNative(cwd, name.trim());
+                    let res = await fmFile().zip(child, dest, { host: host.id });
+                    if (win.disposed) return;
+                    if (res && res.error === 'exists') {
+                        const ok = await openConfirmDialog({
+                            title: 'Zip',
+                            message: 'Overwrite ' + name.trim() + '?',
+                            okLabel: 'Overwrite', danger: true });
+                        if (!ok || win.disposed) return;
+                        res = await fmFile().zip(child, dest,
+                            { host: host.id, overwrite: true });
+                        if (win.disposed) return;
+                    }
+                    if (!(res && res.ok)) {
+                        if (res && res.error === 'auth_required') {
+                            promptFileHostAuth(host);
+                        }
+                        showNotice('zip failed: ' + ((res && res.error) || '?'));
+                        return;
+                    }
+                    showNotice('created ' + name.trim());
+                    renderPane(side);
+                };
+                // Unzip a .zip into a fresh archive-stem sibling dir.
+                const unzipRow = async (ent, child) => {
+                    const host = paneHost(side);
+                    if (!host) {
+                        showNotice('unzip failed: host unavailable');
+                        return;
+                    }
+                    const stem = ent.name.replace(/\.zip$/i, '')
+                        || (ent.name + '_extracted');
+                    const dest = joinNative(cwd, stem);
+                    const res = await fmFile().unzip(child, dest,
+                        { host: host.id });
+                    if (win.disposed) return;
+                    if (!(res && res.ok)) {
+                        if (res && res.error === 'auth_required') {
+                            promptFileHostAuth(host);
+                        }
+                        const err = (res && res.error) || '?';
+                        if (err === 'exists') {
+                            showNotice('unzip failed: "' + stem
+                                + '" already exists');
+                        } else {
+                            showNotice('unzip failed: ' + err);
+                        }
+                        return;
+                    }
+                    showNotice('extracted to ' + stem);
+                    renderPane(side);
+                };
                 const buildRowMenu = (row, ent, child) => {
                     const other = side === 'left' ? 'right' : 'left';
                     const desc = { hostId: win[hostKey(side)], path: child,
@@ -463,6 +598,18 @@
                                  action: () => pasteInto(side, pasteDir) });
                     items.push({ label: 'Rename…', enabled: true,
                                  action: () => renameRow(ent, child) });
+                    if (ent.type !== 'dir') {
+                        items.push({ label: 'Download', enabled: true,
+                                     action: () => downloadRow(ent, child) });
+                    }
+                    items.push({ label: 'Zip', enabled: true,
+                                 action: () => zipRow(ent, child) });
+                    if (ent.type !== 'dir' && /\.zip$/i.test(ent.name)) {
+                        items.push({ label: 'Unzip', enabled: true,
+                                     action: () => unzipRow(ent, child) });
+                    }
+                    items.push({ label: 'Delete', enabled: true,
+                                 action: () => deleteRow(ent, child) });
                     items.push({ sep: true });
                     items.push({ label: 'Copy → ' + other + ' pane',
                                  enabled: true,

--- a/webterm/broker/mods/file-manager/file-manager.js
+++ b/webterm/broker/mods/file-manager/file-manager.js
@@ -617,6 +617,10 @@
                     items.push({ label: 'Move → ' + other + ' pane',
                                  enabled: true,
                                  action: () => doTransfer(other, desc, true) });
+                    items.push({ sep: true });
+                    items.push({ label: 'Properties…', enabled: true,
+                                 action: () => showProperties(side, child,
+                                                              ent.name) });
                     return items;
                 };
                 const onRowMenu = (e, row, ent, child) => {
@@ -1027,11 +1031,52 @@
                 showNotice('created ' + name.trim());
                 renderPane(side);
             };
+            // Properties: /file/stat -> a read-only styled info modal. Shared by
+            // the row menu (a file/dir) and the empty menu (the cwd).
+            const showProperties = async (side, path, displayName) => {
+                const host = paneHost(side);
+                if (!host) {
+                    showNotice('properties failed: host unavailable');
+                    return;
+                }
+                const r = await fmFile().stat(path, { host: host.id });
+                if (win.disposed) return;
+                if (!(r && r.ok)) {
+                    if (r && r.error === 'auth_required') {
+                        promptFileHostAuth(host);
+                    }
+                    showNotice('properties failed: ' + ((r && r.error) || '?'));
+                    return;
+                }
+                const rows = [];
+                rows.push({ k: 'Name',
+                            v: displayName || baseName(r.path || path) });
+                rows.push({ k: 'Path', v: r.path || path });
+                rows.push({ k: 'Type', v: r.type === 'dir' ? 'Folder'
+                            : (r.type === 'file' ? 'File' : r.type) });
+                if (r.type === 'dir') {
+                    if (typeof r.children === 'number') {
+                        rows.push({ k: 'Items', v: String(r.children) });
+                    }
+                } else {
+                    rows.push({ k: 'Size',
+                                v: fmtSize(r.size) + ' (' + r.size + ' bytes)' });
+                }
+                if (r.mtime != null) {
+                    rows.push({ k: 'Modified',
+                                v: new Date(r.mtime * 1000).toLocaleString() });
+                }
+                if (typeof r.mode === 'number') {
+                    rows.push({ k: 'Mode',
+                                v: '0' + (r.mode & 0o7777).toString(8) });
+                }
+                await openInfoModal({ title: 'Properties', rows: rows });
+            };
 
             // Right-click on a pane's empty background: New folder / Paste /
             // Refresh / Properties of the cwd. Lives in the outer scope (reads
             // win[dirKey(side)] live) so the one pane-level contextmenu handler
-            // can call it; the item set grows in later commits.
+            // can call it.
             const buildEmptyMenu = (side) => {
                 const cwd = win[dirKey(side)];
                 const items = [];
@@ -1045,6 +1090,9 @@
                 items.push({ label: 'Refresh', enabled: true,
                              action: () => { renderPane('left');
                                              renderPane('right'); } });
+                items.push({ label: 'Properties…', enabled: true,
+                             action: () => showProperties(side, cwd,
+                                                          baseName(cwd)) });
                 return items;
             };
 

--- a/webterm/broker/ui.py
+++ b/webterm/broker/ui.py
@@ -79,6 +79,9 @@ _ORDERED = [
     "66_js_notices_zorder.js",
     "67_js_window_lifecycle.js",
     "68_js_app_windows_files.js",
+    # Reusable styled dialog primitive (#72, Part A): openDialog + openTextPrompt
+    # / openConfirmDialog / openInfoModal, hoisted globals for core + mods.
+    "69_js_dialog.js",
     # 69_js_codemirror.js + 70_js_editor_app.js were EXTRACTED to mods/editor/
     # (#83/S10); 71_js_file_manager.js to mods/file-manager/ (#84/S11);
     # 72_js_task_manager.js to mods/task-manager/ (#85/S12); the dispatcher


### PR DESCRIPTION
Closes #72.

Adds a full file/folder operation set to the dual-pane file manager plus drag
improvements, backed by new `/file/*` endpoints and a reusable styled dialog
component.

## Backend (`app.py`) — new gated, off-loop `/file/*` endpoints
- `mkdir`, `copy`, `move`, recursive `delete`, `zip`, `unzip`, `stat` — each
  reuses the existing token/loopback gate + host-wide resolution, runs heavy IO
  via `run_in_executor`, and broadens the catch so failures keep the
  `{ok:false,error}` contract (never a 500).
- **Link-safe resolver** (`follow_leaf`, default `True` = byte-identical): the
  headline data-loss fix — deleting/moving a symlink **or Windows junction**
  removes the link entry, never the target tree. `copy` uses
  `copytree(symlinks=True)` + dst-in-src reject; `move` does atomic file replace
  and **backup-and-restore on dir overwrite** so the destination is never lost.
- `zip`/`unzip`: pre-scan size/entry caps (zip-bomb guard), tempfile+replace
  (no partial archive), rely on CPython `extractall` traversal sanitization.
- 7 routes + 7 OPTIONS preflights; a dynamic guard test enforces both for every
  `/file/*` route.

## Frontend
- **Reusable styled dialog** (`69_js_dialog.js`): `openDialog` +
  `openTextPrompt`/`openConfirmDialog`/`openInfoModal`, themed via the shared
  dialog CSS; the FM's own native `confirm()` sites converted to it.
- `ctx.file` extended with `mkdir/copy/move/zip/unzip/stat` + `recursive` delete
  (ctxVersion stays 1); `fmFile()` fallback mirrored for mods-off parity.
- File manager: full row menus (file + dir), empty-area menu, single-item
  clipboard (Cut/Copy/Paste), `doTransfer` dispatcher (same-host server-side /
  cross-host byte path / cross-host-dir refusal), draggable dirs, **Shift-drag =
  move**, Rename/New folder/Zip/Unzip/Delete/Properties.

## Verification
- **590 tests pass** (extended `test_file_api.py` with symlink/junction,
  zip-bomb, traversal, route-guard cases; e2e delete updated; UI-asset
  sentinels).
- Playwright end-to-end against an isolated broker: every menu item, styled
  dialogs (Escape cancels without closing the FM), clipboard, drag copy +
  Shift-drag move, Zip→Unzip round-trip — all verified, **0 console errors**.

## Notes / out of scope
- Cross-host folder copy and >5 MiB download are surfaced as clear notices
  (documented future enhancements).
- Follow-up #89 tracks converting the remaining app-wide native
  `confirm()`/`prompt()` sites to the new dialog component.

The D2–D4 correctness commits (resolver/symlink/zip) were hardened by a codex
adversarial review (reparse-point leaf safety, atomic file replace, dir-overwrite
backup, `BadZipFile` handling).
