### PR TITLE
#89: convert remaining native confirm()/prompt() to the styled dialog

### DIFF
--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -941,6 +941,19 @@ def test_dialog_component_present():
     assert ".app-dialog" in INDEX_HTML
 
 
+def test_no_native_dialogs_in_served_page():
+    # #89: the whole app routes every confirm/prompt through the styled dialog
+    # component — NO native confirm()/prompt()/alert() survives anywhere in the
+    # served page (core + every mod, assembled in one shot). The lookbehind skips
+    # method calls / longer identifiers, and the styled wrappers are capitalized
+    # (openConfirmDialog / openTextPrompt) so they never trip the lowercase match.
+    import re
+    assert not re.search(r"(?<![\w.])(confirm|prompt|alert)\s*\(", ui.INDEX_HTML), \
+        "native confirm()/prompt()/alert() must not survive (use the styled dialog)"
+    for sym in ("openConfirmDialog(", "openTextPrompt("):
+        assert sym in ui.INDEX_HTML, f"styled dialog wrapper missing: {sym!r}"
+
+
 def test_file_capability_richer_ops_present():
     # #72: ctx.file gains mkdir/copy/move/zip/unzip/stat and a recursive flag on
     # delete; ctxVersion stays 1 (additive). The SAME methods are mirrored in the

--- a/webterm/broker/62_js_workspaces.js
+++ b/webterm/broker/62_js_workspaces.js
@@ -329,25 +329,35 @@
             savePrefs();
             renderWorkspaces();
         }
-        function renameWorkspace(i) {
+        async function renameWorkspace(i) {
             const L = getLayout();
             const ws = L.workspaces[i];
             if (!ws) return;
-            const name = prompt('Workspace ' + (i + 1)
-                + ' name (blank = use the number):', ws.name || '');
+            const name = await openTextPrompt({
+                title: 'Rename workspace',
+                label: 'Name',
+                value: ws.name || '',
+                placeholder: 'blank = use the number',
+                okLabel: 'Rename',
+            });
             if (name === null) return;          // cancelled
+            // A state-sync poll-adopt during the await can swap prefs._layout
+            // wholesale, so re-find the live workspace by id before mutating it.
+            const L2 = getLayout();
+            const ws2 = L2.workspaces.find(w => w.id === ws.id);
+            if (!ws2) return;
             const t = name.trim();
             if (t) {
-                ws.name = t.slice(0, 40);
+                ws2.name = t.slice(0, 40);
                 getSettings().wsLabelMode = 'name';   // naming implies showing names
             } else {
-                delete ws.name;
+                delete ws2.name;
             }
             savePrefs();
             renderWorkspaces();
             applyTaskbarWorkspace();
         }
-        function removeWorkspace(i) {
+        async function removeWorkspace(i) {
             const L = getLayout();
             if (L.workspaces.length <= 1) {
                 showNotice('cannot remove the last workspace');
@@ -357,26 +367,42 @@
             const victim = L.workspaces[i];
             const hasContent = (victim.columns && victim.columns.length)
                 || anyFloatingOnWs(victim.id);
-            if (hasContent && !confirm('Remove workspace ' + (i + 1)
-                + '? Its windows move to an adjacent workspace.')) return;
-            const neighborIdx = (i > 0) ? i - 1 : 1;
-            const neighbor = L.workspaces[neighborIdx];
+            if (hasContent) {
+                const ok = await openConfirmDialog({
+                    title: 'Remove workspace',
+                    message: 'Remove workspace ' + (i + 1)
+                        + '? Its windows move to an adjacent workspace.',
+                    okLabel: 'Remove',
+                    danger: true,
+                });
+                if (!ok) return;
+            }
+            // A state-sync poll-adopt during the await can replace prefs._layout
+            // wholesale, so the captured L / victim / i go stale. Re-acquire the
+            // live layout and re-locate the victim by id before mutating.
+            const L2 = getLayout();
+            if (L2.workspaces.length <= 1) return;
+            const vi = L2.workspaces.findIndex(w => w.id === victim.id);
+            if (vi < 0) return;
+            const live = L2.workspaces[vi];
+            const neighborIdx = (vi > 0) ? vi - 1 : 1;
+            const neighbor = L2.workspaces[neighborIdx];
             // Move tiled columns into the neighbor (keeps their windows).
-            for (const col of victim.columns) neighbor.columns.push(col);
+            for (const col of live.columns) neighbor.columns.push(col);
             // Reassign floating windows locked to the victim -> neighbor (by id,
             // so no index bookkeeping is needed across the splice).
-            reassignFloatingWs(victim.id, neighbor.id);
+            reassignFloatingWs(live.id, neighbor.id);
             // Park the victim's tiled windows first so the relayout below never
             // tries to mount them under the now-removed workspace.
-            for (const col of victim.columns) {
+            for (const col of live.columns) {
                 for (const k of columnKeys(col)) parkWindow(windows.get(k));
             }
-            L.workspaces.splice(i, 1);
+            L2.workspaces.splice(vi, 1);
             // Fix the active index.
-            let active = L.activeWs;
-            if (active === i) active = Math.max(0, i - 1);
-            else if (active > i) active -= 1;
-            L.activeWs = Math.max(0, Math.min(active, L.workspaces.length - 1));
+            let active = L2.activeWs;
+            if (active === vi) active = Math.max(0, vi - 1);
+            else if (active > vi) active -= 1;
+            L2.activeWs = Math.max(0, Math.min(active, L2.workspaces.length - 1));
             savePrefs();
             renderWorkspaces();
             relayoutStrip();

--- a/webterm/broker/69_js_dialog.js
+++ b/webterm/broker/69_js_dialog.js
@@ -194,6 +194,12 @@
             }).then(function (r) { return !!(r && r.value); });
         }
 
+        // True while a styled dialog is live (the _dlgFinish singleton is set).
+        // The keybinding dispatcher consults this to suppress modifier-hotkey
+        // actions under an open dialog, so an action can't open a second dialog
+        // that would silently cancel the first.
+        function isAppDialogOpen() { return !!_dlgFinish; }
+
         // Read-only info modal (Properties): a list of {k,v} rows + a Close.
         function openInfoModal(opts) {
             opts = opts || {};

--- a/webterm/broker/73_js_window_runtime.js
+++ b/webterm/broker/73_js_window_runtime.js
@@ -556,7 +556,13 @@
                 // rather than silently dropping the server save.
                 const what = win.tabs ? 'the open documents'
                     : (win.filePath || 'this file');
-                if (confirm('Save changes to ' + what + ' before closing?')) {
+                if (await openConfirmDialog({
+                        title: 'Unsaved changes',
+                        message: 'Save changes to ' + what + ' before closing?',
+                        okLabel: 'Save' })) {
+                    // The /sessions reaper can call closeWindow during the dialog,
+                    // tearing the window down — don't try to save a dead window.
+                    if (win.disposed) return;
                     let ok = false;
                     const saver = win._saveAllDirty || win._saveToServer;
                     if (saver) {

--- a/webterm/broker/78_js_keybindings.js
+++ b/webterm/broker/78_js_keybindings.js
@@ -163,6 +163,11 @@
             // Only honor combos carrying a non-shift modifier, so plain typing
             // (and Shift+letter) is never hijacked into the terminal.
             if (!(e.ctrlKey || e.altKey || e.metaKey)) return;
+            // While a styled dialog is open, suppress hotkey actions: an action
+            // that opens a second dialog would silently cancel the first (the
+            // _dlgFinish singleton). Plain typing, the recorder path above, and
+            // the dialog's own Escape/Enter (handled in capture) are untouched.
+            if (isAppDialogOpen()) return;
             const map = getSettings().keybindings || {};
             let actionId = null;
             for (const id of Object.keys(map)) {

--- a/webterm/broker/78_js_keybindings.js
+++ b/webterm/broker/78_js_keybindings.js
@@ -537,9 +537,12 @@
             // terminal/agent window win.id IS the session key terminateWindow
             // expects.
             if (win.type !== 'app') {
-                items.push({ label: 'Terminate', enabled: true, action: () => {
-                    if (confirm('Terminate this session? '
-                            + 'The shell process tree will be killed.'))
+                items.push({ label: 'Terminate', enabled: true, action: async () => {
+                    if (await openConfirmDialog({
+                            title: 'Terminate session',
+                            message: 'Terminate this session? '
+                                + 'The shell process tree will be killed.',
+                            okLabel: 'Terminate', danger: true }))
                         terminateWindow(win.id);
                 }});
             }
@@ -557,9 +560,12 @@
                 items.push({
                     label: 'Delete ' + what,
                     enabled: true,
-                    action: () => {
-                        if (confirm('Delete this ' + what + ' permanently? '
-                                + 'Its saved content is removed.'))
+                    action: async () => {
+                        if (await openConfirmDialog({
+                                title: 'Delete ' + what,
+                                message: 'Delete this ' + what + ' permanently? '
+                                    + 'Its saved content is removed.',
+                                okLabel: 'Delete', danger: true }))
                             destroyAppWindow(win.id);
                     },
                 });
@@ -662,9 +668,12 @@
             // Terminate: terminals/agents only (app docs have no pid). Enabled
             // whenever the session exists — works on a parked session too.
             if (!isApp) {
-                items.push({ label: 'Terminate', enabled: !!sess, action: () => {
-                    if (confirm('Terminate this session? '
-                            + 'The shell process tree will be killed.'))
+                items.push({ label: 'Terminate', enabled: !!sess, action: async () => {
+                    if (await openConfirmDialog({
+                            title: 'Terminate session',
+                            message: 'Terminate this session? '
+                                + 'The shell process tree will be killed.',
+                            okLabel: 'Terminate', danger: true }))
                         terminateWindow(key);
                 }});
             }

--- a/webterm/broker/83_js_broker_identity.js
+++ b/webterm/broker/83_js_broker_identity.js
@@ -135,10 +135,14 @@
                 } catch (_) {}
                 if (brokerId) {
                     const dup = findHostByBrokerId(brokerId, getHosts());
-                    if (dup && !confirm('This looks like the same broker you '
-                            + 'already have as "' + dup.label
-                            + '". Add anyway?')) {
-                        return;
+                    if (dup) {
+                        const ok = await openConfirmDialog({
+                            title: 'Duplicate broker',
+                            message: 'This looks like the same broker you '
+                                + 'already have as "' + dup.label
+                                + '". Add anyway?',
+                            okLabel: 'Add anyway' });
+                        if (!ok) return;
                     }
                 }
                 // Re-fetch the live array: getHosts() rebuilds prefs._hosts on

--- a/webterm/broker/mods/editor/editor.js
+++ b/webterm/broker/mods/editor/editor.js
@@ -612,9 +612,16 @@
                 win._captureActiveDoc();
                 const fileDocs = win.tabs.filter(d => d.kind === 'file');
                 if (fileDocs.some(d => d.dirty)) {
-                    if (!confirm('Re-home this window to:\n' + newCwd
-                        + '\n\nUnsaved changes in the AGENTS.md / CLAUDE.md tabs '
-                        + 'will be discarded.')) return;
+                    const ok = await openConfirmDialog({
+                        title: 'Re-home window',
+                        message: 'Re-home this window to:\n' + newCwd
+                            + '\n\nUnsaved changes in the AGENTS.md / CLAUDE.md '
+                            + 'tabs will be discarded.',
+                        okLabel: 'Re-home', danger: true });
+                    if (!ok) return;
+                    // The window can be torn down (or its tabs cleared) while the
+                    // dialog is open — re-check before the re-home sequence.
+                    if (win.disposed || !win.tabs) return;
                 }
                 const hid = win.fileHostId || 'local';
                 const host = hostById(hid) || localHost();
@@ -1197,11 +1204,15 @@
                     if (win.filePath) return await writeTo(win.filePath);
                     return await doSaveAs();
                 };
-                // Exposed for Ctrl+S and the close-save prompt (returns a
+                // Exposed for Ctrl+S and the close-save dialog (returns a
                 // truthy result on a successful write).
                 win._saveToServer = doSave;
                 const doOpen = async () => {
-                    if (win.dirty && !confirm('Discard unsaved changes?')) return;
+                    if (win.dirty && !(await openConfirmDialog({
+                            title: 'Discard changes?',
+                            message: 'Discard unsaved changes?',
+                            okLabel: 'Discard', danger: true }))) return;
+                    if (win.disposed) return;
                     // One host for both the browse and the read (see doSaveAs).
                     const h = fileHost();
                     if (!h) { showNotice('open failed: host unavailable'); return; }
@@ -1225,8 +1236,12 @@
                     saveAppWindow(win);
                     showNotice('opened ' + win.filePath);
                 };
-                const doNew = () => {
-                    if (win.dirty && !confirm('Discard unsaved changes?')) return;
+                const doNew = async () => {
+                    if (win.dirty && !(await openConfirmDialog({
+                            title: 'Discard changes?',
+                            message: 'Discard unsaved changes?',
+                            okLabel: 'Discard', danger: true }))) return;
+                    if (win.disposed) return;
                     win.setContent('');
                     win.filePath = null;
                     win.dirty = false;
@@ -1235,6 +1250,7 @@
                     // Cleared path -> plain (no language).
                     if (win._setCmLanguage) win._setCmLanguage();
                     saveAppWindow(win);
+                    if (win.focusEditor) win.focusEditor();
                 };
                 const doWrap = () => {
                     win.wrap = !win.wrap;
@@ -1293,7 +1309,7 @@
                     hostBtn.title = 'reads/writes on: ' + lbl
                         + ' — click to switch host';
                 };
-                const switchEditorHost = (host) => {
+                const switchEditorHost = async (host) => {
                     if (!host || host.id === win.fileHostId) return;
                     // Detach an OPEN file: its absolute path belongs to the OLD
                     // host, and silently re-pointing Save at a same-spelled path
@@ -1310,13 +1326,17 @@
                             || ((!oid || oid === 'local') ? localHost() : null);
                         const oldLbl = oldH ? hostPickerLabel(oldH)
                             : (oid + ' (removed)');
-                        const ok = confirm('Switch this editor to "'
-                            + hostPickerLabel(host) + '"?\n\nIt will detach from '
-                            + oldLbl + ':' + win.filePath
-                            + '\nThe text stays here as an unsaved document; '
-                            + 'Save will write to "' + hostPickerLabel(host)
-                            + '".');
+                        const ok = await openConfirmDialog({
+                            title: 'Switch host',
+                            message: 'Switch this editor to "'
+                                + hostPickerLabel(host) + '"?\n\nIt will detach from '
+                                + oldLbl + ':' + win.filePath
+                                + '\nThe text stays here as an unsaved document; '
+                                + 'Save will write to "' + hostPickerLabel(host)
+                                + '".',
+                            okLabel: 'Switch' });
                         if (!ok) return;
+                        if (win.disposed) return;
                         win.filePath = null;
                         if (win.agentsMdCwd) clearAgentsMd();
                         win.dirty = !!win.getContent();
@@ -1328,6 +1348,8 @@
                     if (win._updateFolderBtn) win._updateFolderBtn();
                     updateFileUi();
                     saveAppWindow(win);
+                    // The confirm dialog stole focus from the editor; restore it.
+                    if (win.focusEditor) win.focusEditor();
                     // Re-prompt the new host's login if it isn't authed yet.
                     editorFile().list('', { host: host.id }).then(r => {
                         if (win.disposed || win.fileHostId !== host.id) return;
@@ -1578,10 +1600,14 @@
                             commitStructural(arr);   // re-renders with the new row
                         });
                         resetBtn.addEventListener('mousedown', stopProp);
-                        resetBtn.addEventListener('click', (e) => {
+                        resetBtn.addEventListener('click', async (e) => {
                             e.stopPropagation();
-                            if (!confirm('Replace the section library with the '
-                                + 'built-in defaults?')) return;
+                            if (!(await openConfirmDialog({
+                                    title: 'Reset sections',
+                                    message: 'Replace the section library with the '
+                                        + 'built-in defaults?',
+                                    okLabel: 'Reset', danger: true }))) return;
+                            if (win.disposed) return;
                             commitStructural(DEFAULT_SECTIONS.map(
                                 t => ({ id: t.id, label: t.label, body: t.body })));
                         });

--- a/webterm/broker/mods/task-manager/task-manager.js
+++ b/webterm/broker/mods/task-manager/task-manager.js
@@ -355,15 +355,26 @@
                         killBtn.textContent = '…';
                     }
                     killBtn.addEventListener('mousedown', stopProp);
-                    killBtn.addEventListener('click', (e) => {
+                    killBtn.addEventListener('click', async (e) => {
                         e.stopPropagation();
+                        // Full if/else so exactly ONE dialog ever opens (an
+                        // if/else-if would let the second guard fire after the
+                        // first resolved, opening a stray dialog).
                         if (isRoot) {
-                            if (!confirm('Kill the shell of "'
-                                + (sess.title || ('#' + sess.id))
-                                + '"? This destroys the window.')) return;
-                        } else if (!confirm('End process ' + proc.pid
-                                + ' (' + (proc.name || '?') + ')?')) {
-                            return;
+                            const ok = await openConfirmDialog({
+                                title: 'Kill shell',
+                                message: 'Kill the shell of "'
+                                    + (sess.title || ('#' + sess.id))
+                                    + '"? This destroys the window.',
+                                okLabel: 'Kill', danger: true });
+                            if (!ok || win.disposed) return;
+                        } else {
+                            const ok = await openConfirmDialog({
+                                title: 'End process',
+                                message: 'End process ' + proc.pid
+                                    + ' (' + (proc.name || '?') + ')?',
+                                okLabel: 'End', danger: true });
+                            if (!ok || win.disposed) return;
                         }
                         endProcess(sess, proc.pid);
                     });
@@ -463,10 +474,14 @@
                         destroyBtn.textContent = '…';
                     }
                     destroyBtn.addEventListener('mousedown', stopProp);
-                    destroyBtn.addEventListener('click', (e) => {
+                    destroyBtn.addEventListener('click', async (e) => {
                         e.stopPropagation();
-                        if (!confirm('Destroy "' + (sess.title || ('#' + sess.id))
-                            + '"? This kills the session.')) return;
+                        const ok = await openConfirmDialog({
+                            title: 'Destroy session',
+                            message: 'Destroy "' + (sess.title || ('#' + sess.id))
+                                + '"? This kills the session.',
+                            okLabel: 'Destroy', danger: true });
+                        if (!ok || win.disposed) return;
                         destroySession(sess);
                     });
                     row.appendChild(destroyBtn);


### PR DESCRIPTION
Closes #89.

Finishes the #72 work: the **15** remaining native `confirm()`/`prompt()` sites across the rest of the UI now use the async styled dialog primitives (`openConfirmDialog` / `openTextPrompt`). After this, the broker tree has **zero** native `confirm(`/`prompt(`/`alert(`.

### What changed
- **Dialog gate** — new `isAppDialogOpen()` helper; the keybinding dispatcher no longer fires hotkey actions while a styled dialog is open (a 2nd dialog would silently cancel the 1st via the `_dlgFinish` singleton). Also retroactively hardens the shipped FM dialogs.
- **Workspaces** — `renameWorkspace` / `removeWorkspace` re-acquire the layout **by id** after the await, since a `/state` poll-adopt can swap `prefs._layout` wholesale.
- **Window/taskbar menus** — Terminate / Delete → async confirm.
- **Save-before-close** — `requestCloseAppWindow` re-checks `win.disposed` after the await (the `/sessions` reaper can tear the window down mid-dialog).
- **Add-host** — duplicate-broker warning → styled confirm.
- **Task-manager** — Kill / End / Destroy; if/else so exactly one dialog shows, plus post-await disposed guards.
- **Editor** — re-home / open / new / switch-host / reset-sections, with disposed re-checks and `win.focusEditor()` focus restore.

Destructive primaries use `danger:true` + a verb label (Terminate / Delete / Kill / End / Destroy / Discard / Remove / Reset), matching the file manager.

### Tests
- New repo-wide guard `test_no_native_dialogs_in_served_page` asserts no native `confirm()`/`prompt()`/`alert()` survives in the assembled served page and that the styled wrappers are present.
- `pytest tests/test_ui_assets.py` → 58 passed. `node --check` on the assembled inline script passes.

### Verification
Driven on a spare-port broker with Playwright + a native-dialog tripwire: workspace rename, editor discard (danger + commit), save-before-close, and the keybinding gate all show **styled** modals (never native), with Escape / backdrop / Cancel all working and zero console errors.